### PR TITLE
Fix a few files for general linux compatibility

### DIFF
--- a/setup/apt-install
+++ b/setup/apt-install
@@ -13,6 +13,6 @@ function do_apt_install {
     PACKAGES_GREP_STRING+=(-e $package)
   done
 
-  apt-get update -y
-  apt-cache --generate pkgnames | grep --line-regexp --fixed-strings $PACKAGES_GREP_STRING | xargs apt install -y
+  sudo apt-get update -y
+  sudo apt-cache --generate pkgnames | grep --line-regexp --fixed-strings $PACKAGES_GREP_STRING | sudo xargs apt install -y
 }

--- a/tag-nvim/config/nvim/lua/custom/plugins.lua
+++ b/tag-nvim/config/nvim/lua/custom/plugins.lua
@@ -36,13 +36,19 @@ return {
     config = function()
       require("crates").setup({
         popup = {
-          autofocus = false,
+          autofocus = true,
         },
         null_ls = {
           enabled = true,
           name = "crates.nvim",
         },
       })
+      local function show_documentation()
+        require("crates").show_popup()
+      end
+
+      vim.keymap.set("n", "K", show_documentation, { silent = true })
+      require("crates").show()
     end,
   },
 }

--- a/tag-ruby/setup/install.apt
+++ b/tag-ruby/setup/install.apt
@@ -4,5 +4,3 @@ apt_install rbenv
 apt_install ruby-build
 apt_install redis
 apt_install openssl
-apt_install docker.io
-apt_install docker-compose

--- a/tag-zsh/config/zsh/2_brew.zsh
+++ b/tag-zsh/config/zsh/2_brew.zsh
@@ -1,9 +1,11 @@
-which brew > /dev/null 2>&1
-
-if [[ $? -eq 1 ]]; then
-  echo $PATH | grep -q "homebrew"
+if [ "$(uname -s)" = "Darwin" ]; then
+  which brew > /dev/null 2>&1
 
   if [[ $? -eq 1 ]]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
+    echo $PATH | grep -q "homebrew"
+
+    if [[ $? -eq 1 ]]; then
+      eval "$(/opt/homebrew/bin/brew shellenv)"
+    fi
   fi
 fi


### PR DESCRIPTION
In order to ensure that setup/setup runs properly on an Ubuntu Linux machine, this commit adds a check for OSX before running anything homebrew related. Additionally, it removes docker packages as these are not available via standard apt repositories and require specific sources added.

Finally, this commit adjusts the crates.nvim plugin for neovim to load when we open a Cargo.toml file and immediately show the version information and make keybinds available.