### PR TITLE
Add lsd.deb instead of using apt package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM golang:${GOLANG_VERSION}-bullseye as go-builder
 FROM buildpack-deps:22.04
 
 ARG APP_ROOT=/workspace
-ARG BUILD_PACKAGES="zsh fish rcm ripgrep luarocks libssl1.1 tmux bat fzf lsd"
+ARG BUILD_PACKAGES="zsh fish rcm ripgrep luarocks libssl1.1 tmux bat fzf"
 
 ENV BUNDLE_APP_CONFIG="$APP_ROOT/.bundle" DEBIAN_FRONTEND=noninteractive
 ENV RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo GOPATH=/go
@@ -23,6 +23,9 @@ WORKDIR $APP_ROOT
 RUN echo "deb http://security.ubuntu.com/ubuntu focal-security main" | tee /etc/apt/sources.list.d/focal-security.list \
     && apt-get update -y \
     && apt-get install -y $BUILD_PACKAGES \
+    && wget https://github.com/lsd-rs/lsd/releases/download/v1.0.0/lsd_1.0.0_amd64.deb \
+    && dpkg -i lsd_1.0.0_amd64.deb \
+    && rm -rf lsd_1.0.0_amd64.deb \
     && apt-get -yqq autoclean \
     && apt-get -yqq autoremove --purge \
     && apt-get -yqq purge $(dpkg --get-selections | grep deinstall | sed s/deinstall//g) \

--- a/tag-nvim/config/nvim/lua/custom/configs/lspconfig.lua
+++ b/tag-nvim/config/nvim/lua/custom/configs/lspconfig.lua
@@ -38,7 +38,7 @@ for _, lsp in ipairs(servers) do
           end)
         end,
         capabilities = capabilities,
-        cmd = { "rustup", "run", "stable", "rust-analyzer" },
+        cmd = { "rust-analyzer" },
         flags = { debounce_text_changes = 150 },
 
         settings = {


### PR DESCRIPTION
This commit removes the apt package for lsd (as it does not existing in 22.04) and replaces it with a downloaded deb package from github
   releases on the lsd project. Additionally, since we don't set a
   default toolchain for rust in a docker environment, this commit
   changes the rust lsp settings to just use the rust-analyzer in our
   path.