### PR TITLE
Fix broken signing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -88,4 +88,4 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --yes 
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I cosign sign --yes {}


### PR DESCRIPTION
In order to ensure container images produced by github actions are signed properly, this commit fixes the syntax for the sign action.