### PR TITLE
Add sshguard and kustomize with KSOPS to NixOS modules

### DIFF
--- a/modules/system/nixos/default.nix
+++ b/modules/system/nixos/default.nix
@@ -58,6 +58,18 @@
       };
     };
 
+    sshguard = {
+      enable = true;
+      attack_threshold = 30;
+      blocktime = 600;
+      detection_time = 1800;
+      whitelist = [
+        "127.0.0.0/8"
+        "100.64.0.0/10"
+        "192.168.1.0/24"
+      ];
+    };
+
     # Enable CUPS for printing
     printing.enable = true;
 

--- a/modules/system/nixos/k3s.nix
+++ b/modules/system/nixos/k3s.nix
@@ -51,11 +51,13 @@
 
   # Kubernetes management tools
   environment.systemPackages = with pkgs; [
-    kubectl      # Kubernetes CLI
+    kubectl          # Kubernetes CLI
     kubernetes-helm  # Helm package manager
-    k9s          # Terminal UI for Kubernetes
-    stern        # Multi-pod log tailing
-    kubectx      # Switch between clusters/namespaces
+    kustomize        # Standalone kustomize (needed for exec plugins)
+    kustomize-sops   # KSOPS - SOPS integration for kustomize
+    k9s              # Terminal UI for Kubernetes
+    stern            # Multi-pod log tailing
+    kubectx          # Switch between clusters/namespaces
   ];
 
   # Set KUBECONFIG environment variable system-wide


### PR DESCRIPTION
SSH brute-force attempts need to be mitigated on NixOS hosts.
sshguard handles this by blocking repeated failed login attempts
while allowing trusted traffic from localhost, Tailscale, and
the local network.

Standalone kustomize and kustomize-sops are needed for managing
encrypted secrets in the k3s cluster. The bundled kustomize in
kubectl doesn't support exec plugins, so a standalone install
is required for KSOPS to function.
