### PR TITLE
Add k9s cli tool to meta cli module

### DIFF
--- a/modules/home/meta/cli.nix
+++ b/modules/home/meta/cli.nix
@@ -30,6 +30,7 @@
     htop
     imagemagick
     jq
+    k9s
     kubectl
     kubectx
     ngrok


### PR DESCRIPTION
In order to make k9s cli tool available everywhere, this commit adds the
package to my cli meta home module.
