### PR TITLE
Update deadmau5 settings for Hyprland and NixOS upstream changes

### DIFF
--- a/config/hypr/configs/window.conf
+++ b/config/hypr/configs/window.conf
@@ -1,29 +1,23 @@
 # vim: ft=hyprlang
 
 # Ignore maximize requests from apps. You'll probably like this.
-windowrulev2 = suppressevent maximize, class:.*
+windowrule = match:class .*, suppress_event maximize
 
 # Fix some dragging issues with XWayland
-windowrulev2 = nofocus,class:^$,title:^$,xwayland:1,floating:1,fullscreen:0,pinned:0
+windowrule = match:class ^$, match:title ^$, match:xwayland 1, match:float 1, match:fullscreen 0, match:pin 0, no_focus on
 
-windowrulev2 = fullscreen,class:^(steam_app_)(.*)$
+windowrule = match:class ^(steam_app_)(.*)$, fullscreen on
 
 # Sushi (GNOME file previewer) - float and center with nice styling
-windowrulev2 = float,class:^(org.gnome.NautilusPreviewer)$
-windowrulev2 = center,class:^(org.gnome.NautilusPreviewer)$
-windowrulev2 = size 1200 800,class:^(org.gnome.NautilusPreviewer)$
-windowrulev2 = opacity 0.95,class:^(org.gnome.NautilusPreviewer)$
-windowrulev2 = float,class:^(discord)$
-windowrulev2 = center,class:^(discord)$
-windowrulev2 = size 1450 850,class:^(discord)$
-windowrulev2 = workspace special:discord,class:^(discord)$
+windowrule = match:class ^(org.gnome.NautilusPreviewer)$, float on
+windowrule = match:class ^(org.gnome.NautilusPreviewer)$, center on
+windowrule = match:class ^(org.gnome.NautilusPreviewer)$, size 1200 800
+windowrule = match:class ^(org.gnome.NautilusPreviewer)$, opacity 0.95
+windowrule = match:class ^(discord)$, float on
+windowrule = match:class ^(discord)$, center on
+windowrule = match:class ^(discord)$, size 1450 850
+windowrule = match:class ^(discord)$, workspace special:discord
 
 # Tweaks to work with blur -----------------------------------
-layerrule = blur, swaync-control-center
-layerrule = blur, swaync-notification-window
-
-layerrule = ignorezero, swaync-control-center
-layerrule = ignorezero, swaync-notification-window
-
-layerrule = ignorealpha 0.5, swaync-control-center
-layerrule = ignorealpha 0.5, swaync-notification-window
+layerrule = blur on, ignore_alpha 0.5, match:namespace swaync-control-center
+layerrule = blur on, ignore_alpha 0.5, match:namespace swaync-notification-window

--- a/modules/home/meta/gui-linux.nix
+++ b/modules/home/meta/gui-linux.nix
@@ -33,7 +33,7 @@
     discord
     wf-recorder
     xdg-utils
-    youtube-music
+    pear-desktop
   ];
 
   gtk = {

--- a/modules/machines/deadmau5/home.nix
+++ b/modules/machines/deadmau5/home.nix
@@ -2,7 +2,7 @@
 
 {
   nixpkgs.config.permittedInsecurePackages = [
-    "ventoy-gtk3-1.1.07"
+    "ventoy-gtk3-1.1.10"
   ];
 
   home.stateVersion = "24.05";

--- a/modules/machines/deadmau5/system.nix
+++ b/modules/machines/deadmau5/system.nix
@@ -4,8 +4,7 @@ let
   githubUser = userConfig.username;
   publicKeysFile = builtins.readFile (pkgs.fetchurl {
     url = "https://github.com/${githubUser}.keys";
-    # sha256 = "1VwDw+Z6+WeWyPrpFE8C8KiR9Iq+GZfH29SgjPZyWC0=";
-    sha256 = "AGdXILIxc/JDkNVjCo/By5FsVAmRZ+MmawzqvcV4SNM=";
+    sha256 = "6KWN+v3skxU1/h0aJBtE/Opli22VFIsv+Z/f3P7oCgs=";
   });
   publicKeys = lib.splitString "\n" (lib.removeSuffix "\n" publicKeysFile);
 in
@@ -23,9 +22,6 @@ in
   services.xserver.videoDrivers = [ "nvidia" ];
 
   services.dnsmasq-resolver.enable = true;
-
-  # Preload daemon - learns usage patterns and preloads frequently used apps
-  services.preload.enable = true;
 
   services.sunshine = {
     enable = true;

--- a/modules/machines/tiesto/system.nix
+++ b/modules/machines/tiesto/system.nix
@@ -4,7 +4,7 @@ let
   githubUser = userConfig.username;
   publicKeysFile = builtins.readFile (pkgs.fetchurl {
     url = "https://github.com/${githubUser}.keys";
-    sha256 = "AGdXILIxc/JDkNVjCo/By5FsVAmRZ+MmawzqvcV4SNM=";
+    sha256 = "6KWN+v3skxU1/h0aJBtE/Opli22VFIsv+Z/f3P7oCgs=";
   });
   publicKeys = lib.splitString "\n" (lib.removeSuffix "\n" publicKeysFile);
 in

--- a/modules/system/nixos/dnsmasq.nix
+++ b/modules/system/nixos/dnsmasq.nix
@@ -19,11 +19,12 @@
     services.resolved = {
       enable = true;
       domains = [ "~${config.services.dnsmasq-resolver.domain}" ];
-      extraConfig = ''
-        [Resolve]
-        DNS=127.0.0.1
-        Domains=~${config.services.dnsmasq-resolver.domain}
-      '';
+      settings = {
+        Resolve = {
+          DNS = "127.0.0.1";
+          Domains = "~${config.services.dnsmasq-resolver.domain}";
+        };
+      };
     };
 
     services.dnsmasq = {


### PR DESCRIPTION
Hyprland deprecated the windowrulev2/layerrule syntax in favor of the
new windowrule format, so the window config needed to be migrated.
Similarly, NixOS deprecated services.resolved.extraConfig freeform
strings in favor of the structured settings attribute set.

SSH keys were rotated, so the fetch hashes are updated on both deadmau5
and tiesto. The ventoy insecure package allowlist is bumped to match the
current version in nixpkgs.

Replaced youtube-music with pear-desktop as the preferred music player
and removed the preload daemon since it wasn't providing noticeable
benefit.