### PR TITLE
Update dosvec network interface name

### DIFF
--- a/modules/machines/dosvec/hardware-configuration.nix
+++ b/modules/machines/dosvec/hardware-configuration.nix
@@ -54,10 +54,10 @@
 
   swapDevices = [ ];
 
-  # Bridge network — enp3s0 bridged to br0 with static IP
+  # Bridge network — enp5s0 bridged to br0 with static IP
   # Required for Plex (hardcodes 192.168.1.104:32400) and LAN-addressable VMs
   networking.useDHCP = false;
-  networking.bridges.br0.interfaces = [ "enp3s0" ];
+  networking.bridges.br0.interfaces = [ "enp5s0" ];
   networking.interfaces.br0 = {
     ipv4.addresses = [{
       address = "192.168.1.104";

--- a/modules/machines/dosvec/system.nix
+++ b/modules/machines/dosvec/system.nix
@@ -8,7 +8,7 @@ let
   publicKeysFile = builtins.readFile (pkgs.fetchurl {
     url = "https://github.com/${githubUser}.keys";
     # sha256 = "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=";
-    sha256 = "AGdXILIxc/JDkNVjCo/By5FsVAmRZ+MmawzqvcV4SNM=";
+    sha256 = "6KWN+v3skxU1/h0aJBtE/Opli22VFIsv+Z/f3P7oCgs=";
   });
   publicKeys = lib.splitString "\n" (lib.removeSuffix "\n" publicKeysFile);
 in

--- a/modules/system/nixos/r8125.nix
+++ b/modules/system/nixos/r8125.nix
@@ -1,5 +1,5 @@
 # Realtek R8125 2.5GbE network driver
-# Required for dosvec's NIC (enp3s0) — NixOS has no DKMS, so we build from source.
+# Required for dosvec's NIC (enp5s0) — NixOS has no DKMS, so we build from source.
 # Source: https://github.com/awesometic/realtek-r8125-dkms
 { config, lib, pkgs, ... }:
 


### PR DESCRIPTION
In order to keep dosvec up to date, this commit updates the network
interface name for my ethernet adapter. This changed due to the new card
installed on the machine re-assigning a pci number to the network card.
