### PR TITLE
Update dosvec ZFS cache limit and weechat soju/libera config

### DIFF
--- a/config/weechat/irc.conf
+++ b/config/weechat/irc.conf
@@ -83,7 +83,6 @@ smart_filter_mode = "+"
 smart_filter_nick = on
 smart_filter_quit = on
 smart_filter_setname = on
-temporary_servers = off
 topic_strip_colors = off
 typing_status_nicks = off
 typing_status_self = off
@@ -200,10 +199,10 @@ soju.tls_priorities
 soju.tls_dhkey_size
 soju.tls_fingerprint
 soju.tls_verify
-soju.password = "on"
-soju.capabilities
+soju.password
+soju.capabilities = "soju.im/bouncer-networks"
 soju.sasl_mechanism = plain
-soju.sasl_username = "endoze/libera"
+soju.sasl_username = "endoze"
 soju.sasl_password = "${sec.data.soju_password}"
 soju.sasl_key
 soju.sasl_timeout
@@ -213,7 +212,7 @@ soju.autoreconnect
 soju.autoreconnect_delay
 soju.nicks
 soju.nicks_alternate
-soju.username = "on"
+soju.username
 soju.realname
 soju.local_hostname
 soju.usermode
@@ -236,3 +235,49 @@ soju.split_msg_max_length
 soju.charset_message
 soju.default_chantypes
 soju.registered_mode
+libera.addresses = "irc.kahdu.org/443"
+libera.proxy
+libera.ipv6
+libera.tls = on
+libera.tls_cert
+libera.tls_password
+libera.tls_priorities
+libera.tls_dhkey_size
+libera.tls_fingerprint
+libera.tls_verify
+libera.password
+libera.capabilities
+libera.sasl_mechanism = plain
+libera.sasl_username = "endoze/libera"
+libera.sasl_password = "${sec.data.soju_password}"
+libera.sasl_key
+libera.sasl_timeout
+libera.sasl_fail
+libera.autoconnect = on
+libera.autoreconnect
+libera.autoreconnect_delay
+libera.nicks
+libera.nicks_alternate
+libera.username
+libera.realname
+libera.local_hostname
+libera.usermode
+libera.command_delay
+libera.command
+libera.autojoin_delay
+libera.autojoin
+libera.autojoin_dynamic
+libera.autorejoin
+libera.autorejoin_delay
+libera.connection_timeout
+libera.anti_flood
+libera.away_check
+libera.away_check_max_nicks
+libera.msg_kick
+libera.msg_part
+libera.msg_quit
+libera.notify
+libera.split_msg_max_length
+libera.charset_message
+libera.default_chantypes
+libera.registered_mode

--- a/config/weechat/weechat.conf
+++ b/config/weechat/weechat.conf
@@ -226,6 +226,7 @@ status_time = default
 base_word_until_cursor = on
 case_sensitive = on
 command_inline = on
+cycle = on
 default_template = "%(nicks)|%(irc_channels)"
 nick_add_space = on
 nick_case_sensitive = off

--- a/modules/machines/dosvec/hardware-configuration.nix
+++ b/modules/machines/dosvec/hardware-configuration.nix
@@ -36,7 +36,10 @@
   boot.initrd.availableKernelModules = [ "xhci_pci" "ahci" "nvme" "usbhid" "usb_storage" "sd_mod" ];
   boot.initrd.kernelModules = [ "dm-snapshot" ];
   boot.kernelModules = [ "kvm-intel" ];
-  boot.kernelParams = [ "pcie_aspm=off" ];
+  boot.kernelParams = [
+    "pcie_aspm=off"
+    "zfs.zfs_arc_max=8589934592"  # 8 GB — limits ARC to reduce total ZFS memory footprint
+  ];
   boot.extraModulePackages = [ ];
 
   # Root filesystem on sda


### PR DESCRIPTION
Soju bouncer-networks capability allows each IRC network to appear as
its own weechat server rather than multiplexing through a single
connection. This gives per-network control over autoconnect, SASL
credentials, and channel management.

ZFS ARC was consuming too much memory on dosvec. Capping it at 8GB keeps
enough cache for reasonable performance while freeing memory for other
workloads.
