### PR TITLE
Fix nvim base46 highlights cache issue

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -78,8 +78,8 @@ require("lazy").setup({
 }, lazy_config)
 
 -- load theme
-dofile(vim.g.base46_cache .. "defaults")
-dofile(vim.g.base46_cache .. "statusline")
+pcall(dofile, vim.g.base46_cache .. "defaults")
+pcall(dofile, vim.g.base46_cache .. "statusline")
 
 require("options")
 require("autocmds")


### PR DESCRIPTION
In order to fix an issue where the cache directory for base46 doesn't
yet exist on a machine, this commit wraps the dofile calls for loading
this cache with pcall. This allows the calls to fail silently and later
let base46 build the directory and cache it needs for subsequent
launches. The problem was a chicken/egg problem where in order to load
the cache, we needed to allow the cache loading to fail so we could
create the directory where the cache should go and generate it.
