### PR TITLE
feat(fish): expand worktree function into subcommand-based CLI

### DIFF
--- a/config/fish/completions/worktree.fish
+++ b/config/fish/completions/worktree.fish
@@ -1,0 +1,43 @@
+function __fish_worktree_branches
+  set -l git_common_dir (git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+  set -l main_root (string replace -r '/\.git$' '' $git_common_dir)
+  set -l worktrees_dir "$main_root/.worktrees"
+
+  if test -d "$worktrees_dir"
+    for dir in $worktrees_dir/*/
+      basename $dir
+    end
+  end
+end
+
+function __fish_worktree_needs_subcommand
+  set -l cmd (commandline -opc)
+
+  if test (count $cmd) -eq 1
+    return 0
+  end
+
+  return 1
+end
+
+function __fish_worktree_using_subcommand
+  set -l cmd (commandline -opc)
+
+  if test (count $cmd) -ge 2 -a "$cmd[2]" = "$argv[1]"
+    return 0
+  end
+
+  return 1
+end
+
+complete -c worktree -f
+
+complete -c worktree -n __fish_worktree_needs_subcommand -a add -d "Create a new worktree"
+complete -c worktree -n __fish_worktree_needs_subcommand -a list -d "List all worktrees"
+complete -c worktree -n __fish_worktree_needs_subcommand -a remove -d "Remove a worktree"
+complete -c worktree -n __fish_worktree_needs_subcommand -a merged -d "Check if branch is merged into origin/main"
+
+complete -c worktree -n '__fish_worktree_using_subcommand add' -a '(__fish_git_branches)' -d "Branch"
+complete -c worktree -n '__fish_worktree_using_subcommand remove' -a '(__fish_worktree_branches)' -d "Worktree"
+complete -c worktree -n '__fish_worktree_using_subcommand remove' -s f -l force -d "Force removal"
+complete -c worktree -n '__fish_worktree_using_subcommand merged' -a '(__fish_worktree_branches)' -d "Branch"

--- a/config/fish/functions/worktree.fish
+++ b/config/fish/functions/worktree.fish
@@ -1,6 +1,14 @@
-function worktree -a branch_name base_branch -d "Create a new git worktree in .worktrees subdirectory"
-  if test -z "$branch_name"
-    echo "Usage: worktree <branch-name> [base-branch]"
+function worktree -d "Manage git worktrees in .worktrees subdirectory"
+  if test (count $argv) -lt 1
+    echo "Usage: worktree <subcommand> [args]"
+    echo ""
+    echo "Subcommands:"
+    echo "  add <branch> [base]   Create a new worktree"
+    echo "  list                  List all worktrees"
+    echo "  remove <name> [-f]    Remove a worktree"
+    echo "  merged <branch>       Check if branch is merged into origin/main"
+    echo ""
+    echo "Other subcommands are passed through to git worktree."
 
     return 1
   end
@@ -11,21 +19,104 @@ function worktree -a branch_name base_branch -d "Create a new git worktree in .w
     return 1
   end
 
-  set worktree_path ".worktrees/$branch_name"
+  set -l git_common_dir (git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+  set -l main_root (string replace -r '/\.git$' '' $git_common_dir)
+  set -l worktrees_dir "$main_root/.worktrees"
 
-  if test -d "$worktree_path"
-    echo "Error: Worktree directory '$worktree_path' already exists"
+  set -l subcommand $argv[1]
+  set -l args $argv[2..]
 
-    return 1
-  end
+  switch $subcommand
+    case add
+      set -l branch_name $args[1]
+      set -l base_branch $args[2]
 
-  if git show-ref --verify --quiet "refs/heads/$branch_name"
-    git worktree add "$worktree_path" "$branch_name"
-  else
-    if test -n "$base_branch"
-      git worktree add "$worktree_path" -b "$branch_name" "$base_branch"
-    else
-      git worktree add "$worktree_path" -b "$branch_name"
-    end
+      if test -z "$branch_name"
+        echo "Usage: worktree add <branch-name> [base-branch]"
+
+        return 1
+      end
+
+      set -l worktree_path "$worktrees_dir/$branch_name"
+
+      if test -d "$worktree_path"
+        echo "Error: Worktree directory '$worktree_path' already exists"
+
+        return 1
+      end
+
+      if git show-ref --verify --quiet "refs/heads/$branch_name"
+        git worktree add "$worktree_path" "$branch_name"
+      else
+        if test -n "$base_branch"
+          git worktree add "$worktree_path" -b "$branch_name" "$base_branch"
+        else
+          git worktree add "$worktree_path" -b "$branch_name"
+        end
+      end
+
+    case list
+      git worktree list $args | string replace (dirname $main_root)"/" ""
+
+    case remove
+      set -l force false
+      set -l name ""
+
+      for arg in $args
+        switch $arg
+          case --force -f
+            set force true
+          case '*'
+            set name $arg
+        end
+      end
+
+      if test -z "$name"
+        echo "Usage: worktree remove <name> [--force]"
+
+        return 1
+      end
+
+      set -l worktree_path "$worktrees_dir/$name"
+
+      if not test -d "$worktree_path"
+        echo "Error: Worktree '$name' not found in $worktrees_dir"
+
+        return 1
+      end
+
+      if test $force = true
+        git worktree remove --force "$worktree_path"
+      else
+        git worktree remove "$worktree_path"
+      end
+
+    case merged
+      set -l branch_name $args[1]
+
+      if test -z "$branch_name"
+        echo "Usage: worktree merged <branch>"
+
+        return 1
+      end
+
+      git fetch origin main &>/dev/null
+
+      set -l unmerged (git cherry origin/main $branch_name 2>/dev/null)
+
+      if test $status -ne 0
+        echo "Error: Could not compare '$branch_name' with origin/main"
+
+        return 1
+      end
+
+      if test -z "$unmerged"
+        echo "Merged"
+      else
+        echo "Not merged"
+      end
+
+    case '*'
+      git worktree $subcommand $args
   end
 end


### PR DESCRIPTION
The original worktree function only supported creating new worktrees,
requiring separate git commands for listing, removing, and checking
merge status. This restructures it as a subcommand interface (add, list,
remove, merged) to provide a single entry point for common worktree
workflows. Paths are now resolved via git-common-dir so the command
works correctly when run from inside a worktree. Fish shell completions
are included for all subcommands and their arguments.
