### PR TITLE
Add FHS build environment for mise and optimize tool installation strategy

### DIFF
--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -11,8 +11,7 @@ java = "24"
 jj = "latest"
 lua = "5.1"
 node = "22"
-ocaml = "5.2"
-python = "3.13"
+opam = "latest"
 ruby = "4.0.0"
 rust = { version = "stable", profile = "default" }  # includes rustc, cargo, rust-std, rust-docs, rustfmt, clippy
 yarn = "3.8.7"
@@ -20,8 +19,15 @@ uv = "latest"
 gleam = "latest"
 pnpm = "latest"
 
+
 [settings]
 # Use experimental features for better compatibility
 experimental = true
 legacy_version_file = true
 idiomatic_version_file_enable_tools = ["ruby", "rust"]
+
+[settings.node]
+compile = false
+
+[settings.ruby]
+compile = false

--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,22 @@
         in
         dockerContainer.dockerImage;
 
+      packages.x86_64-linux.mise-compile =
+        let
+          miseFhs = import ./modules/system/nixos/mise-fhs-env.nix {
+            pkgs = nixpkgsFor.x86_64-linux;
+          };
+        in
+        miseFhs.package;
+
+      devShells.x86_64-linux.mise-compile =
+        let
+          miseFhs = import ./modules/system/nixos/mise-fhs-env.nix {
+            pkgs = nixpkgsFor.x86_64-linux;
+          };
+        in
+        miseFhs.shell;
+
       homeConfigurations = {
         "macbook" = mkHome { name = "macbook"; system = "aarch64-darwin"; };
         "workmac" = mkHome { name = "workmac"; system = "aarch64-darwin"; };

--- a/modules/machines/dosvec/system.nix
+++ b/modules/machines/dosvec/system.nix
@@ -14,6 +14,7 @@
     ../../system/nixos/coral-tpu.nix # Google Coral TPU
     ../../system/nixos/tailscale.nix # VPN as system service
     ../../system/nixos/r8125.nix # Realtek R8125 2.5GbE driver
+    ../../system/nixos/nix-ld.nix # Dynamic library shim for unpatched binaries
   ];
 
   # ==========================================================================
@@ -128,23 +129,6 @@
       kga = "kubectl get all";
       kgn = "kubectl get nodes";
     };
-  };
-
-  # Dynamic library shim for running unpatched binaries
-  programs.nix-ld = {
-    enable = true;
-    libraries = with pkgs; [
-      stdenv.cc.cc.lib
-      zlib
-      readline.dev
-      readline
-      ncurses.dev
-      ncurses
-      icu
-      openssl
-      krb5
-      curl
-    ];
   };
 
   # Server-specific packages

--- a/modules/machines/dosvec/zfs-datasets.nix
+++ b/modules/machines/dosvec/zfs-datasets.nix
@@ -41,6 +41,7 @@ let
       compression = "lz4";
       atime = "off";
       recordsize = "1M"; # Optimized for large media files
+      secondarycache = "none"; # L2ARC not useful for streaming media
     };
     "hermes/backups" = {
       mountpoint = "/mnt/hermes/backups";
@@ -98,6 +99,7 @@ let
     check_prop "hermes/Media" "compression" "lz4"
     check_prop "hermes/Media" "atime" "off"
     check_prop "hermes/Media" "recordsize" "1M"
+    check_prop "hermes/Media" "secondarycache" "none"
 
     # hermes/backups
     check_prop "hermes/backups" "compression" "lz4"

--- a/modules/system/meta/gui-nixos.nix
+++ b/modules/system/meta/gui-nixos.nix
@@ -7,6 +7,7 @@
     ../nixos/hyprland.nix
     ../nixos/steam.nix
     ../nixos/tailscale.nix
+    ../nixos/nix-ld.nix
   ];
 
   environment.systemPackages = with pkgs; [
@@ -43,22 +44,6 @@
     };
 
     xfconf.enable = true;
-
-    nix-ld = {
-      enable = true;
-      libraries = with pkgs; [
-        stdenv.cc.cc.lib
-        zlib
-        readline.dev
-        readline
-        ncurses.dev
-        ncurses
-        icu
-        openssl
-        krb5
-        curl
-      ];
-    };
   };
 
   xdg = {

--- a/modules/system/nixos/default.nix
+++ b/modules/system/nixos/default.nix
@@ -56,6 +56,12 @@
       settings = {
         PasswordAuthentication = false;
         PermitRootLogin = "no";
+        Macs = [
+          "hmac-sha2-512-etm@openssh.com"
+          "hmac-sha2-256-etm@openssh.com"
+          "umac-128-etm@openssh.com"
+          "hmac-sha2-512"
+        ];
       };
     };
 

--- a/modules/system/nixos/mise-fhs-env.nix
+++ b/modules/system/nixos/mise-fhs-env.nix
@@ -1,0 +1,69 @@
+# buildFHSEnv for compiling language toolchains via mise on NixOS
+#
+# Usage:
+#   nix develop ~/.dotfiles#mise-compile   # interactive shell
+#   nix run ~/.dotfiles#mise-compile       # one-shot mise install
+{ pkgs }:
+
+let
+  fhsEnv = pkgs.buildFHSEnv {
+    name = "mise-compile";
+
+    extraOutputsToInstall = [ "dev" ];
+
+    targetPkgs = pkgs: with pkgs; [
+      # Core toolchain
+      gcc
+      gnumake
+      autoconf
+      automake
+      pkg-config
+      patch
+      perl
+
+      # Shared libraries (with .dev for headers)
+      zlib
+      zlib.dev
+      openssl
+      openssl.dev
+      readline
+      readline.dev
+      ncurses
+      ncurses.dev
+      curl
+      curl.dev
+      libxml2
+      libxml2.dev
+      libxslt
+      libxslt.dev
+
+      # Erlang
+      gnum4
+      wxGTK32
+      mesa
+      libGL
+      libGLU
+      unixODBC
+
+      # General utilities
+      git
+      wget
+      cacert
+      which
+      file
+      mise
+      bash
+    ];
+
+    profile = ''
+      export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+      export MISE_DATA_DIR="$HOME/.local/share/mise"
+    '';
+  };
+in
+{
+  shell = fhsEnv.env;
+  package = pkgs.writeShellScriptBin "mise-compile" ''
+    exec ${fhsEnv}/bin/mise-compile -c "mise install && exit"
+  '';
+}

--- a/modules/system/nixos/nix-ld.nix
+++ b/modules/system/nixos/nix-ld.nix
@@ -1,0 +1,34 @@
+# nix-ld - Dynamic library shim for running unpatched binaries
+{ config, pkgs, lib, ... }:
+
+{
+  programs.nix-ld = {
+    enable = true;
+    libraries = with pkgs; [
+      stdenv.cc.cc.lib
+      zlib
+      readline.dev
+      readline
+      ncurses.dev
+      ncurses
+      icu
+      openssl
+      krb5
+      curl
+      libffi
+      libyaml
+      gdbm
+      sqlite
+      bzip2
+      xz
+      expat
+      libxcrypt
+      gmp
+      libGL
+      glib
+      libxml2
+      libxslt
+      unixODBC
+    ];
+  };
+}


### PR DESCRIPTION
On NixOS, mise needs an FHS-compatible environment to compile tools from
source since standard paths like /usr/include don't exist. This adds a
buildFHSEnv shell (nix develop/run ~/.dotfiles#mise-compile) for erlang
and lua, which must compile from source. Node and ruby are switched to
precompiled binaries to avoid unnecessary compilation, and python is
removed entirely in favor of uv which manages its own installations.

The nix-ld configuration is centralized into a shared module with
expanded runtime libraries so precompiled binaries can find their
dependencies outside the FHS environment.

Also adds SSH MAC algorithm compatibility for mobile SSH clients and
disables L2ARC for the ZFS media dataset where sequential streaming
makes it ineffective.
