### PR TITLE
Add nix to treesitter install

### DIFF
--- a/config/nvim/lua/plugins/nvim-treesitter.lua
+++ b/config/nvim/lua/plugins/nvim-treesitter.lua
@@ -18,6 +18,7 @@ return {
       "javascript",
       "lua",
       "luadoc",
+      "nix",
       "php",
       "printf",
       "ruby",


### PR DESCRIPTION
In order to ensure nix syntax gets installed, this commit updates the
list of installed treesitter parsers we install to include nix.
