### PR TITLE
Add ungoogled chromium and policies

### DIFF
--- a/modules/home/linux/chromium.nix
+++ b/modules/home/linux/chromium.nix
@@ -1,0 +1,20 @@
+{ config, pkgs, lib, ... }:
+
+{
+  programs.chromium = {
+    enable = true;
+    package = pkgs.ungoogled-chromium;
+
+    extensions = [
+      {
+        # chromium-web-store - enables installing extensions from Chrome Web Store
+        id = "ocaahdebbfolfmndjeplogmgcagdmblk";
+        updateUrl = "https://raw.githubusercontent.com/NeverDecaf/chromium-web-store/master/updates.xml";
+      }
+    ];
+
+    commandLineArgs = [
+      "--extension-mime-request-handling=always-prompt-for-install"
+    ];
+  };
+}

--- a/modules/home/meta/gui-linux.nix
+++ b/modules/home/meta/gui-linux.nix
@@ -18,6 +18,7 @@
     ../linux/cliphist.nix
     ../linux/nm-applet.nix
     ../linux/blueman-applet.nix
+    ../linux/chromium.nix
     ../linux/hypridle.nix
   ];
 

--- a/modules/system/common/chromium-policies.nix
+++ b/modules/system/common/chromium-policies.nix
@@ -1,0 +1,19 @@
+{
+  # Homepage
+  HomepageLocation = "https://start.duckduckgo.com";
+  HomepageIsNewTabPage = false;
+
+  # Restore tabs from last session on launch
+  RestoreOnStartup = 1;
+
+  # Default search engine
+  DefaultSearchProviderEnabled = true;
+  DefaultSearchProviderName = "DuckDuckGo";
+  DefaultSearchProviderSearchURL = "https://duckduckgo.com/?q={searchTerms}";
+  DefaultSearchProviderSuggestURL = "https://duckduckgo.com/ac/?q={searchTerms}&type=list";
+
+  # Disable password manager
+  PasswordManagerEnabled = false;
+  AutofillAddressEnabled = false;
+  AutofillCreditCardEnabled = false;
+}

--- a/modules/system/darwin/chromium.nix
+++ b/modules/system/darwin/chromium.nix
@@ -1,0 +1,8 @@
+{ config, pkgs, lib, ... }:
+
+let
+  policies = import ../common/chromium-policies.nix;
+in
+{
+  system.defaults.CustomUserPreferences."org.chromium.Chromium" = policies;
+}

--- a/modules/system/meta/gui-darwin.nix
+++ b/modules/system/meta/gui-darwin.nix
@@ -1,9 +1,14 @@
 { config, pkgs, lib, ... }:
 
 {
+  imports = [
+    ../darwin/chromium.nix
+  ];
+
   homebrew.casks = [
     "alfred"
     "claude"
+    "eloston-chromium"
     "ghostty"
     "karabiner-elements"
     "orbstack"

--- a/modules/system/meta/gui-nixos.nix
+++ b/modules/system/meta/gui-nixos.nix
@@ -7,6 +7,7 @@
     ../nixos/hyprland.nix
     ../nixos/steam.nix
     ../nixos/tailscale.nix
+    ../nixos/chromium.nix
     ../nixos/nix-ld.nix
   ];
 

--- a/modules/system/nixos/chromium.nix
+++ b/modules/system/nixos/chromium.nix
@@ -1,0 +1,8 @@
+{ config, pkgs, lib, ... }:
+
+let
+  policies = import ../common/chromium-policies.nix;
+in
+{
+  environment.etc."chromium/policies/managed/policies.json".text = builtins.toJSON policies;
+}


### PR DESCRIPTION
In order to enable chromium usage without google and to control settings
'the nix way', this commit adds ungoogled chromium for linux via the
nixpkg and homebrew cask for macos. This is purely because a nix build
for macos is not available. It also adds a shareable policies module
that we use in a platform specific way so chromium on each platform
pick it up correctly.
