### PR TITLE
Set up GPG signing and pinentry on dosvec

### DIFF
--- a/modules/machines/dosvec/home.nix
+++ b/modules/machines/dosvec/home.nix
@@ -7,6 +7,12 @@
     ../../home/meta/cli.nix
   ];
 
+  services.gpg-agent = {
+    pinentry.package = lib.mkForce pkgs.pinentry-curses;
+    defaultCacheTtl = 86400;
+    maxCacheTtl = 86400;
+  };
+
   home.packages = with pkgs; [
     readline
     readline.dev

--- a/modules/machines/dosvec/system.nix
+++ b/modules/machines/dosvec/system.nix
@@ -104,6 +104,7 @@
       443 # HTTPS
       6443 # k3s API (also in k3s.nix, but explicit here)
       6697 # Soju IRC
+      7000 # FRP
       8554 # Frigate RTSP
       8555 # Frigate WebRTC
       32400 # Plex
@@ -205,13 +206,6 @@
     "net.ipv4.conf.default.rp_filter" = 2; # Strict mode drops legitimate packets with br0/flannel/tailscale
   };
 
-  # Disable suspend/hibernate - server should always be on
-  systemd.sleep.extraConfig = ''
-    AllowSuspend=no
-    AllowHibernation=no
-    AllowSuspendThenHibernate=no
-    AllowHybridSleep=no
-  '';
 
   # Enable automatic upgrades (optional, can be disabled)
   # system.autoUpgrade = {


### PR DESCRIPTION
GPG commit signing on dosvec (a headless server) requires a
terminal-based pinentry program since there is no GUI. Force
pinentry-curses and cache the passphrase for 24 hours to avoid
repeated prompts during development sessions.

Also open port 7000 for FRP and remove the explicit sleep
inhibitor config that is unnecessary given the server's role.
