### PR TITLE
fix(zfs): disable block cloning to prevent hung-task watchdog trips

### DIFF
--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -31,7 +31,7 @@
   "nvim-nio": { "branch": "master", "commit": "21f5324bfac14e22ba26553caf69ec76ae8a7662" },
   "nvim-surround": { "branch": "main", "commit": "61319d4bd1c5e336e197defa15bd104c51f0fb29" },
   "nvim-tree.lua": { "branch": "master", "commit": "3603f069ff783c31986894a56c2a6755331b0802" },
-  "nvim-treesitter": { "branch": "master", "commit": "7caec274fd19c12b55902a5b795100d21531391f" },
+  "nvim-treesitter": { "branch": "main", "commit": "7caec274fd19c12b55902a5b795100d21531391f" },
   "nvim-web-devicons": { "branch": "master", "commit": "d7462543c9e366c0d196c7f67a945eaaf5d99414" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "render-markdown.nvim": { "branch": "main", "commit": "e3c18ddd27a853f85a6f513a864cf4f2982b9f26" },

--- a/modules/system/nixos/zfs.nix
+++ b/modules/system/nixos/zfs.nix
@@ -18,6 +18,16 @@
     # Explicitly import the hermes pool during boot
     # Required since root is not on ZFS
     zfs.extraPools = [ "hermes" ];
+
+    # Disable ZFS block cloning (copy_file_range via zfs_clone_range).
+    # Loki's compactor issues copy_file_range() on /mnt/hermes/docker/loki/data;
+    # under concurrent snapshot/write load the clone path blocks in
+    # txg_wait_synced() long enough to trip the 122s hung-task watchdog and
+    # fail the pod's liveness probe. The pool predates the block-cloning
+    # feature and nothing here depends on it, so turn it off at module load.
+    extraModprobeConfig = ''
+      options zfs zfs_bclone_enabled=0
+    '';
   };
 
   services.zfs = {


### PR DESCRIPTION
Loki's compactor calls copy_file_range() on its data directory under
/mnt/hermes, which routes through ZFS's block cloning path. Under
concurrent snapshot and write load, the clone operation blocks inside
txg_wait_synced() long enough to cross the 122s hung-task threshold,
which in turn fails the pod's liveness probe and restarts Loki.

The hermes pool predates the block-cloning feature and nothing running
against it relies on cloned extents, so disabling the feature at the
module level is a safe way to force copy_file_range() to fall back to
an ordinary copy and avoid the stall entirely.

Also bumps nvim-treesitter's tracked branch to main following its
upstream rename
