### PR TITLE
Add attic binary cache module for all NixOS machines

### DIFF
--- a/modules/machines/archimedes/system.nix
+++ b/modules/machines/archimedes/system.nix
@@ -13,6 +13,7 @@
     ../../system/meta/cli-nixos.nix
     ../../system/nixos/tailscale.nix
     ../../system/nixos/nix-ld.nix
+    ../../system/nixos/attic-cache.nix
   ];
 
   # ==========================================================================

--- a/modules/machines/deadmau5/system.nix
+++ b/modules/machines/deadmau5/system.nix
@@ -8,6 +8,7 @@
     # Machine-specific: nvidia GPU and custom pipewire config
     ../../system/nixos/nvidia.nix
     ../../system/nixos/pipewire.nix
+    ../../system/nixos/attic-cache.nix
   ];
 
   sops = {

--- a/modules/machines/dosvec/system.nix
+++ b/modules/machines/dosvec/system.nix
@@ -15,6 +15,7 @@
     ../../system/nixos/tailscale.nix # VPN as system service
     ../../system/nixos/r8125.nix # Realtek R8125 2.5GbE driver
     ../../system/nixos/nix-ld.nix # Dynamic library shim for unpatched binaries
+    ../../system/nixos/attic-cache.nix # cache.kahdu.org/main substituter + attic login
   ];
 
   # ==========================================================================

--- a/modules/system/nixos/attic-cache.nix
+++ b/modules/system/nixos/attic-cache.nix
@@ -1,0 +1,38 @@
+{ config, pkgs, lib, userConfig, ... }:
+
+let
+  serverName = "dosvec";
+  endpoint = "https://cache.kahdu.org/";
+  substituterUrl = "https://cache.kahdu.org/main";
+  publicKey = "main:ch1Il2WBscgvKTDg00wIqQCT/wSyqlA7lD0n2m2VkOg=";
+  cacheHost = "cache.kahdu.org";
+in
+{
+  nix.settings = {
+    substituters = [ substituterUrl ];
+    trusted-public-keys = [ publicKey ];
+    netrc-file = config.sops.templates."nix-netrc".path;
+  };
+
+  environment.systemPackages = [ pkgs.attic-client ];
+
+  sops.templates."nix-netrc" = {
+    content = ''
+      machine ${cacheHost}
+      password ${config.sops.placeholder."attic-admin-key"}
+    '';
+  };
+
+  sops.templates."attic-config.toml" = {
+    path = "${userConfig.homeDirectory}/.config/attic/config.toml";
+    owner = userConfig.username;
+    mode = "0400";
+    content = ''
+      default-server = "${serverName}"
+
+      [servers.${serverName}]
+      endpoint = "${endpoint}"
+      token = "${config.sops.placeholder."attic-admin-key"}"
+    '';
+  };
+}


### PR DESCRIPTION
Machines were repeatedly rebuilding identical derivations from source,
wasting significant CPU time and bandwidth during rebuilds. With the
attic server already deployed and the admin key distributed via sops,
the remaining work was wiring each machine up as a client so builds
can be shared across the fleet.

This module centralizes the substituter URL, public key, and netrc
configuration in one place so individual machine configs only need
a single import. It also drops an attic config template into the
user's home so interactive `attic push` and `attic pull` commands
authenticate automatically without additional setup.
