### PR TITLE
Add Plymouth boot splash to deadmau5

### DIFF
--- a/modules/machines/deadmau5/system.nix
+++ b/modules/machines/deadmau5/system.nix
@@ -9,6 +9,7 @@
     ../../system/nixos/nvidia.nix
     ../../system/nixos/pipewire.nix
     ../../system/nixos/attic-cache.nix
+    ../../system/nixos/plymouth.nix
   ];
 
   sops = {

--- a/modules/system/nixos/plymouth.nix
+++ b/modules/system/nixos/plymouth.nix
@@ -1,0 +1,25 @@
+{ pkgs, ... }:
+
+{
+  boot = {
+    plymouth = {
+      enable = true;
+      themePackages = [ pkgs.adi1090x-plymouth-themes ];
+      theme = "hud_space";
+    };
+
+    consoleLogLevel = 0;
+    initrd.verbose = false;
+    kernelParams = [
+      "quiet"
+      "loglevel=3"
+      "splash"
+      "boot.shell_on_fail"
+      "rd.systemd.show_status=false"
+      "rd.udev.log_level=3"
+      "udev.log_priority=3"
+      "systemd.show_status=false"
+      "vt.global_cursor_default=0"
+    ];
+  };
+}


### PR DESCRIPTION
Replace the verbose default boot console output with a graphical
splash screen to provide a cleaner, more polished boot experience
on the deadmau5 workstation.

The accompanying kernel parameters and log level adjustments
suppress the usual boot diagnostics so the splash is not
interrupted by kernel, systemd, or udev messages, while
boot.shell_on_fail preserves access to a recovery shell if
something goes wrong during early boot.

Packaging this as a reusable module under modules/system/nixos
lets other machines opt in later without duplicating the
configuration.
