### PR TITLE
Move database client tools to CLI module

### DIFF
--- a/modules/home/common/mysql.nix
+++ b/modules/home/common/mysql.nix
@@ -25,63 +25,69 @@ in
     };
   };
 
-  config = lib.mkIf config.programs.mysql.enable {
-    home.packages = [ pkgs.mysql84 ];
+  config = lib.mkMerge [
+    (lib.mkIf config.programs.mysql.enable {
+      home.packages = [ pkgs.mysql84 ];
 
-    home.file.".my.cnf".text = ''
-      [mysqld]
-      socket=${mysqlSocketPath}
-      bind-address = 0.0.0.0
-      port = 3306
-      mysqlx_socket=${mysqlxSocketPath}
-      disable_log_bin
-      character-set-server = utf8mb4
-      collation-server = utf8mb4_unicode_ci
-      [client]
-      socket=${mysqlSocketPath}
-    '';
+      home.file.".my.cnf".text = ''
+        [mysqld]
+        socket=${mysqlSocketPath}
+        bind-address = 0.0.0.0
+        port = 3306
+        mysqlx_socket=${mysqlxSocketPath}
+        disable_log_bin
+        character-set-server = utf8mb4
+        collation-server = utf8mb4_unicode_ci
+        [client]
+        socket=${mysqlSocketPath}
+      '';
 
-    launchd.agents.mysql = lib.mkIf isDarwin {
-      enable = true;
-      config = {
-        ProgramArguments = [
-          "${mysqlBin}/mysqld"
-          "--basedir=${pkgs.mysql84}"
-          "--datadir=${mysqlDataDir}"
-          "--log-error=${mysqlBaseDir}/mysqld.local.err"
-          "--pid-file=${mysqlBaseDir}/mysqld.local.pid"
-        ];
-        RunAtLoad = config.programs.mysql.runAtLoad;
-        KeepAlive = {
-          Crashed = true;
-          SuccessfulExit = false;
+      launchd.agents.mysql = lib.mkIf isDarwin {
+        enable = true;
+        config = {
+          ProgramArguments = [
+            "${mysqlBin}/mysqld"
+            "--basedir=${pkgs.mysql84}"
+            "--datadir=${mysqlDataDir}"
+            "--log-error=${mysqlBaseDir}/mysqld.local.err"
+            "--pid-file=${mysqlBaseDir}/mysqld.local.pid"
+          ];
+          RunAtLoad = config.programs.mysql.runAtLoad;
+          KeepAlive = {
+            Crashed = true;
+            SuccessfulExit = false;
+          };
+          WorkingDirectory = mysqlBaseDir;
         };
-        WorkingDirectory = mysqlBaseDir;
       };
-    };
 
-    systemd.user.services.mysql = lib.mkIf isLinux {
-      Unit = {
-        Description = "MySQL Server";
-        After = [ "network.target" ];
+      systemd.user.services.mysql = lib.mkIf isLinux {
+        Unit = {
+          Description = "MySQL Server";
+          After = [ "network.target" ];
+        };
+        Service = {
+          Type = "notify";
+          ExecStart = "${mysqlBin}/mysqld --basedir=${pkgs.mysql84} --datadir=${mysqlDataDir} --log-error=${mysqlBaseDir}/mysqld.local.err --pid-file=${mysqlBaseDir}/mysqld.local.pid";
+          Restart = "on-failure";
+          RestartSec = "5s";
+          WorkingDirectory = mysqlBaseDir;
+        };
+        Install = {
+          WantedBy = if config.programs.mysql.runAtLoad then [ "default.target" ] else [ ];
+        };
       };
-      Service = {
-        Type = "notify";
-        ExecStart = "${mysqlBin}/mysqld --basedir=${pkgs.mysql84} --datadir=${mysqlDataDir} --log-error=${mysqlBaseDir}/mysqld.local.err --pid-file=${mysqlBaseDir}/mysqld.local.pid";
-        Restart = "on-failure";
-        RestartSec = "5s";
-        WorkingDirectory = mysqlBaseDir;
-      };
-      Install = {
-        WantedBy = if config.programs.mysql.runAtLoad then [ "default.target" ] else [ ];
-      };
-    };
 
-    home.activation.initMysqlDataDir = lib.hm.dag.entryAfter [ "writeBoundry" ] ''
-      if [[ ! -d "${mysqlDataDir}" ]]; then
-        mkdir -p ${mysqlDataDir}
-        ${mysqlBin}/mysqld --initialize-insecure --datadir=${mysqlDataDir}
-      fi
-    '';
-  };
+      home.activation.initMysqlDataDir = lib.hm.dag.entryAfter [ "writeBoundry" ] ''
+        if [[ ! -d "${mysqlDataDir}" ]]; then
+          mkdir -p ${mysqlDataDir}
+          ${mysqlBin}/mysqld --initialize-insecure --datadir=${mysqlDataDir}
+        fi
+      '';
+    })
+
+    (lib.mkIf (!config.programs.mysql.enable) {
+      home.packages = [ pkgs.mariadb.client ];
+    })
+  ];
 }

--- a/modules/home/common/postgres.nix
+++ b/modules/home/common/postgres.nix
@@ -26,46 +26,52 @@ in
     };
   };
 
-  config = lib.mkIf config.programs.postgres.enable {
-    home.packages = [ postgresqlWithExtensions ];
+  config = lib.mkMerge [
+    (lib.mkIf config.programs.postgres.enable {
+      home.packages = [ postgresqlWithExtensions ];
 
-    launchd.agents.postgres = lib.mkIf isDarwin {
-      enable = true;
-      config = {
-        ProgramArguments = [
-          "${postgresBin}/postgres"
-          "-D"
-          postgresDataDir
-        ];
-        RunAtLoad = config.programs.postgres.runAtLoad;
-        KeepAlive = {
-          Crashed = true;
-          SuccessfulExit = false;
+      launchd.agents.postgres = lib.mkIf isDarwin {
+        enable = true;
+        config = {
+          ProgramArguments = [
+            "${postgresBin}/postgres"
+            "-D"
+            postgresDataDir
+          ];
+          RunAtLoad = config.programs.postgres.runAtLoad;
+          KeepAlive = {
+            Crashed = true;
+            SuccessfulExit = false;
+          };
         };
       };
-    };
 
-    systemd.user.services.postgres = lib.mkIf isLinux {
-      Unit = {
-        Description = "PostgreSQL Server";
-        After = [ "network.target" ];
+      systemd.user.services.postgres = lib.mkIf isLinux {
+        Unit = {
+          Description = "PostgreSQL Server";
+          After = [ "network.target" ];
+        };
+        Service = {
+          Type = "notify";
+          ExecStart = "${postgresBin}/postgres -D ${postgresDataDir}";
+          Restart = "on-failure";
+          RestartSec = "5s";
+        };
+        Install = {
+          WantedBy = if config.programs.postgres.runAtLoad then [ "default.target" ] else [ ];
+        };
       };
-      Service = {
-        Type = "notify";
-        ExecStart = "${postgresBin}/postgres -D ${postgresDataDir}";
-        Restart = "on-failure";
-        RestartSec = "5s";
-      };
-      Install = {
-        WantedBy = if config.programs.postgres.runAtLoad then [ "default.target" ] else [ ];
-      };
-    };
 
-    home.activation.initPostgresDataDir = lib.hm.dag.entryAfter [ "writeBoundry" ] ''
-      if [[ ! -d "${postgresDataDir}" ]]; then
-        mkdir -p ${postgresDataDir}
-        ${postgresBin}/initdb -D ${postgresDataDir}
-      fi
-    '';
-  };
+      home.activation.initPostgresDataDir = lib.hm.dag.entryAfter [ "writeBoundry" ] ''
+        if [[ ! -d "${postgresDataDir}" ]]; then
+          mkdir -p ${postgresDataDir}
+          ${postgresBin}/initdb -D ${postgresDataDir}
+        fi
+      '';
+    })
+
+    (lib.mkIf (!config.programs.postgres.enable) {
+      home.packages = [ pkgs.postgresql ];
+    })
+  ];
 }

--- a/modules/home/meta/cli.nix
+++ b/modules/home/meta/cli.nix
@@ -5,6 +5,7 @@
 
   imports = [
     ../common/bat.nix
+    ../common/databases.nix
     ../common/fastfetch.nix
     ../common/fish.nix
     ../common/git.nix
@@ -39,11 +40,6 @@
     htop
     imagemagick
     jq
-  ] ++ lib.optionals (!config.programs.postgres.enable) [
-    postgresql
-  ] ++ lib.optionals (!config.programs.mysql.enable) [
-    mariadb.client
-  ] ++ [
     sqlite
     k9s
     kubectl

--- a/modules/home/meta/gui-darwin.nix
+++ b/modules/home/meta/gui-darwin.nix
@@ -4,7 +4,6 @@
   imports = [
     ../common/firefox.nix
     ../common/ghostty.nix
-    ../common/databases.nix
     ../darwin/karabiner.nix
   ];
 

--- a/modules/home/meta/gui-linux.nix
+++ b/modules/home/meta/gui-linux.nix
@@ -12,7 +12,6 @@
   imports = [
     ../common/firefox.nix
     ../common/ghostty.nix
-    ../common/databases.nix
     ../linux/dconf.nix
     ../linux/gnome-keyring.nix
     ../linux/hyprland.nix


### PR DESCRIPTION
Database client tools (psql, mariadb client) were previously only
available on GUI hosts because the databases import lived in the
gui-darwin and gui-linux meta modules. This meant headless or
CLI-only environments lacked basic database connectivity tooling
even though those workflows commonly need it.

Move the databases import into the CLI meta module so client tools
ship everywhere, and rework mysql.nix and postgres.nix to use
lib.mkMerge so they always provide client packages while still
gating the full server setup behind their respective enable flags.
The package conditionals previously inlined in cli.nix are no
longer needed since each module now owns its own client fallback.
