### PR TITLE
Fix clipboard shortcuts targeting wrong window on Hyprland

### DIFF
--- a/config/hypr/scripts/clipboard.sh
+++ b/config/hypr/scripts/clipboard.sh
@@ -17,9 +17,9 @@ case "$active_class" in
   # google-chrome, chromium: Chromium browser
   firefox|Claude|discord|Slack|r2modman|steam|google-chrome|chromium)
     case "$action" in
-      copy)  hyprctl dispatch sendshortcut ctrl, c, ;;
-      paste) hyprctl dispatch sendshortcut ctrl, v, ;;
-      cut)   hyprctl dispatch sendshortcut ctrl, x, ;;
+      copy)  hyprctl dispatch sendshortcut "ctrl, c, activewindow" ;;
+      paste) hyprctl dispatch sendshortcut "ctrl, v, activewindow" ;;
+      cut)   hyprctl dispatch sendshortcut "ctrl, x, activewindow" ;;
     esac
     ;;
   # Default: use XF86 keysyms for all other apps (GTK, Qt, terminals, etc.)


### PR DESCRIPTION
The sendshortcut dispatcher was being invoked with a trailing
empty argument rather than an explicit window target. Without
specifying activewindow, Hyprland could not reliably route the
synthesized Ctrl+C/V/X events to the focused application,
causing copy/paste/cut to silently fail in browsers, Discord,
Slack, and other Chromium- or Electron-based apps that require
real keyboard shortcuts instead of the XF86 clipboard keysyms.

Quoting the full dispatcher argument and adding activewindow as
the target ensures the shortcut is delivered to the app the
user is actually interacting with.
