### PR TITLE
Improve font rendering and tune terminal size on Linux

### DIFF
--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -5,7 +5,7 @@ monitor = , preferred, auto, 1
 
 source = ~/.config/hypr/configs/env.conf
 
-$terminal = ghostty --font-size=18
+$terminal = ghostty --font-size=16
 $fileManager = env GSK_RENDERER=ngl nautilus --no-desktop
 $menu = walker
 $browser = firefox

--- a/modules/home/linux/fontconfig.nix
+++ b/modules/home/linux/fontconfig.nix
@@ -1,0 +1,16 @@
+{ ... }:
+
+{
+  xdg.configFile."fontconfig/conf.d/10-mac-like.conf".text = ''
+    <?xml version="1.0"?>
+    <!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+    <fontconfig>
+      <match target="font">
+        <edit name="hintstyle" mode="assign"><const>hintslight</const></edit>
+        <edit name="antialias" mode="assign"><bool>true</bool></edit>
+        <edit name="rgba"      mode="assign"><const>none</const></edit>
+        <edit name="embeddedbitmap" mode="assign"><bool>false</bool></edit>
+      </match>
+    </fontconfig>
+  '';
+}

--- a/modules/home/meta/gui-linux.nix
+++ b/modules/home/meta/gui-linux.nix
@@ -26,6 +26,7 @@
     ../linux/nm-applet.nix
     ../linux/chromium.nix
     ../linux/hypridle.nix
+    ../linux/fontconfig.nix
   ];
 
   home.packages = with pkgs; [


### PR DESCRIPTION
Add a fontconfig snippet that switches Linux font rendering to
slight hinting with grayscale antialiasing (no subpixel RGBA, no
embedded bitmaps). This produces a softer, more macOS-like
appearance and avoids the color fringing that subpixel rendering
can introduce on this display.

Drop the Ghostty font size from 18 to 16 so terminal text matches
the rest of the desktop more comfortably at the current display
scaling, reducing the need to resize windows to fit useful content.
