### PR TITLE
Make the Attic cache actually useful across the fleet

### DIFF
--- a/modules/home/darwin.nix
+++ b/modules/home/darwin.nix
@@ -1,6 +1,10 @@
 { config, pkgs, lib, ... }:
 
 {
+  imports = [
+    ./darwin/attic-cache.nix
+  ];
+
   nixpkgs.config = {
     allowUnsupportedSystem = true;
     allowUnfree = true;

--- a/modules/home/darwin/attic-cache.nix
+++ b/modules/home/darwin/attic-cache.nix
@@ -1,0 +1,21 @@
+{ config, pkgs, lib, ... }:
+
+let
+  substituterUrl = "https://cache.kahdu.org/main";
+  publicKey = "main:ch1Il2WBscgvKTDg00wIqQCT/wSyqlA7lD0n2m2VkOg=";
+  # Must match sops.templates."nix-netrc".path in
+  # modules/system/darwin/attic-cache.nix.
+  netrcPath = "/etc/nix/netrc";
+in
+{
+  # Drops ~/.config/nix/nix.conf to add the kahdu Attic cache as a substituter.
+  # Determinate Nix reads this in addition to /etc/nix/nix.conf and
+  # /etc/nix/nix.custom.conf - all merge. Requires this user to be in
+  # `trusted-users` (Determinate's installer adds the installing user by
+  # default; check with `nix show-config | grep '^trusted-users'`).
+  xdg.configFile."nix/nix.conf".text = ''
+    extra-substituters = ${substituterUrl}
+    extra-trusted-public-keys = ${publicKey}
+    netrc-file = ${netrcPath}
+  '';
+}

--- a/modules/machines/macbook/system.nix
+++ b/modules/machines/macbook/system.nix
@@ -4,6 +4,7 @@
   imports = [
     ../../system/meta/cli-darwin.nix
     ../../system/meta/gui-darwin.nix
+    ../../system/darwin/attic-cache.nix
   ];
 
   sops = {

--- a/modules/machines/workmac/system.nix
+++ b/modules/machines/workmac/system.nix
@@ -4,6 +4,7 @@
   imports = [
     ../../system/meta/cli-darwin.nix
     ../../system/meta/gui-darwin.nix
+    ../../system/darwin/attic-cache.nix
   ];
 
   sops = {

--- a/modules/system/darwin/attic-cache.nix
+++ b/modules/system/darwin/attic-cache.nix
@@ -1,0 +1,56 @@
+{ config, pkgs, lib, userConfig, ... }:
+
+let
+  serverName = "dosvec";
+  endpoint = "https://cache.kahdu.org/";
+  publicKey = "main:ch1Il2WBscgvKTDg00wIqQCT/wSyqlA7lD0n2m2VkOg=";
+  cacheHost = "cache.kahdu.org";
+in
+{
+  environment.systemPackages = [ pkgs.attic-client ];
+
+  sops.templates."nix-netrc" = {
+    # Explicit path so the home-manager nix.conf can reference it.
+    # nix-daemon runs as root and can read this regardless of mode/owner.
+    path = "/etc/nix/netrc";
+    content = ''
+      machine ${cacheHost}
+      password ${config.sops.placeholder."attic-admin-key"}
+    '';
+  };
+
+  sops.templates."attic-config.toml" = {
+    path = "${userConfig.homeDirectory}/.config/attic/config.toml";
+    owner = userConfig.username;
+    mode = "0400";
+    content = ''
+      default-server = "${serverName}"
+
+      [servers.${serverName}]
+      endpoint = "${endpoint}"
+      token = "${config.sops.placeholder."attic-admin-key"}"
+    '';
+  };
+
+  # Note on substituters (PULL): nix-darwin's nix is disabled in favor of
+  # Determinate Nix, so `nix.settings` here would be a no-op. To make this
+  # host pull from cache.kahdu.org, configure Determinate's nix.conf
+  # separately (e.g. /etc/nix/nix.custom.conf). This module only wires up
+  # the PUSH side (watch-store).
+
+  launchd.daemons.attic-watch-store = {
+    serviceConfig = {
+      Label = "org.kahdu.attic-watch-store";
+      ProgramArguments = [
+        "${pkgs.attic-client}/bin/attic"
+        "watch-store"
+        "--jobs"
+        "2"
+        "${serverName}:main"
+      ];
+      KeepAlive = true;
+      RunAtLoad = true;
+      UserName = userConfig.username;
+    };
+  };
+}

--- a/modules/system/nixos/attic-cache.nix
+++ b/modules/system/nixos/attic-cache.nix
@@ -35,4 +35,24 @@ in
       token = "${config.sops.placeholder."attic-admin-key"}"
     '';
   };
+
+  systemd.services.attic-watch-store = {
+    description = "Attic - watch /nix/store and push new paths to ${serverName}:main";
+    after = [ "network-online.target" "sops-nix.service" ];
+    wants = [ "network-online.target" "sops-nix.service" ];
+    wantedBy = [ "multi-user.target" ];
+    restartTriggers = [
+      config.sops.secrets."attic-admin-key".sopsFile
+      config.sops.templates."attic-config.toml".content
+    ];
+    serviceConfig = {
+      Type = "exec";
+      ExecStart = "${pkgs.attic-client}/bin/attic watch-store --jobs 2 ${serverName}:main";
+      Restart = "on-failure";
+      RestartSec = "10s";
+      User = userConfig.username;
+      Group = "users";
+      NoNewPrivileges = true;
+    };
+  };
 }


### PR DESCRIPTION
The cache was provisioned and reachable but nothing was
pushing to it continuously, so every build on every machine
still fetched every leaf path from upstream. The 141 paths
already in it were a one-shot manual push from an Orin
build months ago.

watch-store is the lowest-friction fix: one always-on daemon
catches every new store path with no per-build decision.
Running it everywhere means the cache populates organically
and each subsequent build across the fleet starts hitting
warmer.

The Mac side needed more wiring than the Linux side. With
nix-darwin's nix disabled in favor of Determinate Nix,
`nix.settings` is silently ignored, so the substituter
config goes through `~/.config/nix/nix.conf` via
home-manager rather than the system nix.conf. The full
attic-client + sops template setup also had to be added
since the Macs weren't importing the cache module before.
