### PR TITLE
fix(attic): authenticate Nix daemon and user against kahdu cache

### DIFF
--- a/modules/home/darwin/attic-cache.nix
+++ b/modules/home/darwin/attic-cache.nix
@@ -3,9 +3,10 @@
 let
   substituterUrl = "https://cache.kahdu.org/main";
   publicKey = "main:ch1Il2WBscgvKTDg00wIqQCT/wSyqlA7lD0n2m2VkOg=";
-  # Must match sops.templates."nix-netrc".path in
-  # modules/system/darwin/attic-cache.nix.
-  netrcPath = "/etc/nix/netrc";
+  # Must match sops.templates."user-nix-netrc".path in
+  # modules/system/darwin/attic-cache.nix. This is the user-readable copy;
+  # the daemon uses a separate root-owned copy at /etc/nix/netrc.
+  netrcPath = "${config.home.homeDirectory}/.config/nix/netrc";
 in
 {
   # Drops ~/.config/nix/nix.conf to add the kahdu Attic cache as a substituter.

--- a/modules/system/darwin/attic-cache.nix
+++ b/modules/system/darwin/attic-cache.nix
@@ -3,18 +3,36 @@
 let
   serverName = "dosvec";
   endpoint = "https://cache.kahdu.org/";
+  substituterUrl = "https://cache.kahdu.org/main";
   publicKey = "main:ch1Il2WBscgvKTDg00wIqQCT/wSyqlA7lD0n2m2VkOg=";
   cacheHost = "cache.kahdu.org";
+  netrcPath = "/etc/nix/netrc";
 in
 {
   environment.systemPackages = [ pkgs.attic-client ];
 
   sops.templates."nix-netrc" = {
-    # Explicit path so the home-manager nix.conf can reference it.
-    # nix-daemon runs as root and can read this regardless of mode/owner.
-    path = "/etc/nix/netrc";
+    # Root-readable copy used by the Nix daemon (Determinate merges this in
+    # via /etc/determinate/config.json -> additionalNetrcSources).
+    path = netrcPath;
     content = ''
       machine ${cacheHost}
+      login attic
+      password ${config.sops.placeholder."attic-admin-key"}
+    '';
+  };
+
+  sops.templates."user-nix-netrc" = {
+    # User-readable copy referenced from home-manager's ~/.config/nix/nix.conf
+    # so user-context commands (nix copy --from, nix store info --store, etc.)
+    # can authenticate. Same secret as the root copy above; separate file
+    # because the sops-rendered root copy is 0400 root and unreadable to user.
+    path = "${userConfig.homeDirectory}/.config/nix/netrc";
+    owner = userConfig.username;
+    mode = "0400";
+    content = ''
+      machine ${cacheHost}
+      login attic
       password ${config.sops.placeholder."attic-admin-key"}
     '';
   };
@@ -32,11 +50,35 @@ in
     '';
   };
 
-  # Note on substituters (PULL): nix-darwin's nix is disabled in favor of
-  # Determinate Nix, so `nix.settings` here would be a no-op. To make this
-  # host pull from cache.kahdu.org, configure Determinate's nix.conf
-  # separately (e.g. /etc/nix/nix.custom.conf). This module only wires up
-  # the PUSH side (watch-store).
+  # PULL side: nix-darwin's nix is disabled in favor of Determinate Nix, so
+  # `nix.settings` would be a no-op. Instead we configure the daemon two ways:
+  #
+  # 1. Determinate's own config tells it to merge our sops-rendered netrc
+  #    into the synthesized /nix/var/determinate/netrc — additive, leaves
+  #    Determinate's FlakeHub entries intact.
+  # 2. An activation script appends substituter + public-key lines to the
+  #    machine-local /etc/nix/nix.custom.conf only if absent — preserves
+  #    whatever else that file holds (it differs per host).
+  environment.etc."determinate/config.json".text = builtins.toJSON {
+    authentication.additionalNetrcSources = [ netrcPath ];
+  };
+
+  system.activationScripts.postActivation.text = ''
+    customConf=/etc/nix/nix.custom.conf
+    changed=0
+    ensure_line() {
+      local line="$1"
+      if ! /usr/bin/grep -qxF "$line" "$customConf" 2>/dev/null; then
+        printf '%s\n' "$line" >> "$customConf"
+        changed=1
+      fi
+    }
+    ensure_line "extra-substituters = ${substituterUrl}"
+    ensure_line "extra-trusted-public-keys = ${publicKey}"
+    if [ "$changed" -eq 1 ]; then
+      /bin/launchctl kickstart -k system/systems.determinate.nix-daemon || true
+    fi
+  '';
 
   launchd.daemons.attic-watch-store = {
     serviceConfig = {

--- a/modules/system/nixos/attic-cache.nix
+++ b/modules/system/nixos/attic-cache.nix
@@ -19,6 +19,7 @@ in
   sops.templates."nix-netrc" = {
     content = ''
       machine ${cacheHost}
+      login attic
       password ${config.sops.placeholder."attic-admin-key"}
     '';
   };


### PR DESCRIPTION
The Attic cache at cache.kahdu.org was reachable but every fetch returned
401. Two reasons: the netrc entry had no login field, so curl's netrc
parser dropped it and sent no auth; and the Determinate-managed daemon
was reading its own synthesized netrc that didn't know about kahdu at
all. The home-manager nix.conf had been pointing at a root-only netrc,
so user-context commands like nix copy --from also couldn't authenticate.

Determinate exposes additionalNetrcSources via /etc/determinate/config.json
for exactly this case, so we feed it the sops-rendered netrc and let it
merge - Determinate keeps owning its file, FlakeHub auth stays intact. A
small activation script appends the substituter URL and public key to
/etc/nix/nix.custom.conf only when absent, so per-host customizations on
each Mac are preserved. A second sops template renders a user-owned copy
of the same netrc so non-root nix commands can authenticate too.
