### PR TITLE
chore(attic): move push log to /var/log and rotate with newsyslog

### DIFF
--- a/modules/system/darwin/attic-cache.nix
+++ b/modules/system/darwin/attic-cache.nix
@@ -148,6 +148,12 @@ in
   # writer briefly closes between bursts - without this, the daemon would
   # exit after every quiet period and KeepAlive would flap. HOME=/var/root
   # makes attic find /var/root/.config/attic/config.toml for credentials.
+  #
+  # Output is captured to /var/log/attic-push.log, the conventional macOS
+  # location for daemon logs. newsyslog (Apple's built-in rotator, run hourly
+  # by /System/Library/LaunchDaemons/com.apple.newsyslog.plist) trims and
+  # gzips it per the rule installed below. Tail with:
+  #   tail -f /var/log/attic-push.log
   launchd.daemons.attic-push-stdin = {
     serviceConfig = {
       Label = "org.kahdu.attic-push-stdin";
@@ -160,8 +166,19 @@ in
       };
       KeepAlive = true;
       RunAtLoad = true;
-      StandardOutPath = "/tmp/attic-push.log";
-      StandardErrorPath = "/tmp/attic-push.log";
+      StandardOutPath = "/var/log/attic-push.log";
+      StandardErrorPath = "/var/log/attic-push.log";
     };
   };
+
+  # newsyslog rule: rotate at 1 MB, keep 5 gzip-compressed archives.
+  # Format: logfilename [owner:group] mode count size when flags
+  #   size  = KB threshold (1024 = 1 MB)
+  #   when  = '*' means size-triggered only (no time-based rotation)
+  #   flags = Z (gzip rotated logs), N (don't signal any process post-rotate;
+  #           launchd reopens the file on next write because we don't hold
+  #           it open across rotations - simple StandardOutPath redirect)
+  environment.etc."newsyslog.d/attic-push.conf".text = ''
+    /var/log/attic-push.log    root:wheel    644  5    1024  *     ZN
+  '';
 }


### PR DESCRIPTION
The attic-push-stdin daemon was writing to /tmp/attic-push.log, which
is wiped on reboot and unbounded in size between reboots. On a
long-lived Darwin host that pushes after every build, the log can
grow large enough to be a nuisance and is lost exactly when it would
be most useful for post-incident debugging.

Switching to /var/log aligns with the conventional macOS location for
daemon output and lets us hand rotation off to newsyslog, which Apple
already runs hourly via com.apple.newsyslog.plist. A size-triggered
rule (1 MB, five gzip archives) keeps disk usage bounded without
introducing another scheduled job, and the N flag avoids needing to
signal launchd since the simple StandardOutPath redirect doesn't hold
the file open across rotations.
