### PR TITLE
attic: allow user nix auth and stop bouncing watcher on secret renders

### DIFF
--- a/modules/system/nixos/attic-cache.nix
+++ b/modules/system/nixos/attic-cache.nix
@@ -17,6 +17,13 @@ in
   environment.systemPackages = [ pkgs.attic-client ];
 
   sops.templates."nix-netrc" = {
+    # User-readable so user-context nix commands (nix path-info --store
+    # https://..., nix copy --from, etc.) can authenticate. nix-daemon runs
+    # as root and can still read it regardless of owner. The attic admin key
+    # is already exposed to the user via ~/.config/attic/config.toml below,
+    # so this is no widening of trust.
+    owner = userConfig.username;
+    mode = "0400";
     content = ''
       machine ${cacheHost}
       login attic
@@ -42,10 +49,6 @@ in
     after = [ "network-online.target" "sops-nix.service" ];
     wants = [ "network-online.target" "sops-nix.service" ];
     wantedBy = [ "multi-user.target" ];
-    restartTriggers = [
-      config.sops.secrets."attic-admin-key".sopsFile
-      config.sops.templates."attic-config.toml".content
-    ];
     serviceConfig = {
       Type = "exec";
       ExecStart = "${pkgs.attic-client}/bin/attic watch-store --jobs 2 ${serverName}:main";


### PR DESCRIPTION
User-context nix commands (`nix path-info --store https://...`,
`nix copy --from`, etc.) need to read the netrc to authenticate
against cache.kahdu.org, but the sops template defaulted to
root-only. Setting owner to the primary user lets user-context
tools authenticate while nix-daemon (running as root) can still
read it regardless. This is no widening of trust since the same
admin key is already exposed to the user via
~/.config/attic/config.toml.

The restart triggers on attic-watch-store caused the watcher to
bounce every time sops re-rendered the admin key or the attic
config template, which happens on every system activation even
when the underlying values are unchanged. Killing and restarting
the long-running watcher interrupts in-flight pushes and forces
it to re-scan /nix/store on startup; since the service already
re-reads the netrc/config from disk on its own restart cycle,
the triggers add churn without protecting any invariant.
