### PR TITLE
fix(fish): resolve direnv async race and harden shell startup

### DIFF
--- a/config/fish/conf.d/direnv.fish
+++ b/config/fish/conf.d/direnv.fish
@@ -5,21 +5,31 @@ if status is-interactive && command -v direnv >/dev/null 2>&1
   function __direnv_export_eval --on-event fish_prompt
       set -l prev_status $status
       if set -q __direnv_async_file
-          if test -f $__direnv_async_file
+          if not test -f $__direnv_async_file
+              # File vanished; reset.
+              set -e __direnv_async_file __direnv_async_pid
+          else if string match -q '# __direnv_done_marker' <$__direnv_async_file
+              # Done. Sentinel is a harmless comment when sourced.
               source $__direnv_async_file 2>/dev/null
+              rm -f $__direnv_async_file
+              set -e __direnv_async_file __direnv_async_pid
+          else if set -q __direnv_async_pid
+              and kill -0 $__direnv_async_pid 2>/dev/null
+              # Background still running; recheck next prompt.
+              return $prev_status
+          else
+              # Background gone without sentinel (killed/crashed); recover.
+              rm -f $__direnv_async_file
+              set -e __direnv_async_file __direnv_async_pid
           end
-          rm -f $__direnv_async_file
-          set -e __direnv_async_file
       end
       set -g __direnv_async_file (mktemp /tmp/direnv.XXXXXXXXXX)
-      command direnv export fish >$__direnv_async_file 2>/dev/null </dev/null &
-      disown
+      begin
+          command direnv export fish 2>/dev/null </dev/null
+          echo '# __direnv_done_marker'
+      end >$__direnv_async_file &
+      set -g __direnv_async_pid $last_pid
+      disown 2>/dev/null
       return $prev_status
-  end
-
-  function __direnv_cd_hook --on-variable PWD
-      set -g __direnv_async_file (mktemp /tmp/direnv.XXXXXXXXXX)
-      command direnv export fish >$__direnv_async_file 2>/dev/null </dev/null &
-      disown
   end
 end

--- a/config/fish/conf.d/mise.fish
+++ b/config/fish/conf.d/mise.fish
@@ -7,6 +7,5 @@ if status is-interactive
 
   if test -d $mise_shims_dir
     fish_add_path -m $mise_shims_dir
-    mise activate fish | source
   end
 end

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -18,5 +18,13 @@ if status is-interactive && command -v starship >/dev/null 2>&1
   # stop visual bell from doing anything
   printf "\e[?1042l"
 
-  starship init fish | source
+  set -l starship_cache $HOME/.cache/fish/starship-init.fish
+  set -l starship_bin (command -v starship)
+
+  if not test -f $starship_cache
+      or test $starship_bin -nt $starship_cache
+    test -d (dirname $starship_cache); or mkdir -p (dirname $starship_cache)
+    starship init fish --print-full-init >$starship_cache
+  end
+  source $starship_cache
 end

--- a/config/fish/functions/is_linux.fish
+++ b/config/fish/functions/is_linux.fish
@@ -1,3 +1,6 @@
 function is_linux --description "Check if running on Linux"
-  test (uname -s) = "Linux"
+  if not set -q __os_kind
+    set -g __os_kind (uname -s)
+  end
+  test "$__os_kind" = Linux
 end

--- a/config/fish/functions/is_macos.fish
+++ b/config/fish/functions/is_macos.fish
@@ -1,3 +1,6 @@
 function is_macos --description "Check if running on macOS"
-  test (uname -s) = "Darwin"
+  if not set -q __os_kind
+    set -g __os_kind (uname -s)
+  end
+  test "$__os_kind" = Darwin
 end

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -12,7 +12,7 @@ java = "24"
 jj = "latest"
 lua = "5.1"
 node = "24"
-opam = "latest"
+"github:ocaml/opam" = { version = "latest", version_prefix = "" }
 ruby = "4.0.0"
 rust = { version = "stable", profile = "default" }  # includes rustc, cargo, rust-std, rust-docs, rustfmt, clippy
 yarn = "3.8.7"

--- a/config/nvim/lua/lsp/languages.lua
+++ b/config/nvim/lua/lsp/languages.lua
@@ -14,6 +14,7 @@ return {
   "lua_ls",
   "marksman",
   "nil_ls",
+  "ocamllsp",
   "roslyn_ls",
   -- "pylsp",
   "ruby_lsp",

--- a/config/nvim/lua/lsp/ocamllsp.lua
+++ b/config/nvim/lua/lsp/ocamllsp.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+function M.setup()
+  local helpers = require("lsp.helpers")
+
+  helpers.setup_lsp("ocamllsp", {
+    autoformat = false, -- let none-ls handle this via ocamlformat
+    cmd = { "ocamllsp" },
+  })
+end
+
+return M

--- a/config/nvim/lua/plugins/none-ls.lua
+++ b/config/nvim/lua/plugins/none-ls.lua
@@ -19,6 +19,8 @@ return {
         },
       }),
 
+      b.formatting.ocamlformat,
+
       b.formatting.stylua,
       b.diagnostics.selene.with({
         cwd = function(_)


### PR DESCRIPTION
The fish_prompt direnv handler could source a tempfile while the
background `direnv export` was still writing it, producing partial
state and stray definitions. Track the worker pid and only source
once a sentinel marker confirms completion; recover cleanly if the
worker dies. Drop the redundant PWD hook since fish_prompt already
fires on directory change.

Also cache starship's init script and memoize `uname` in
is_linux/is_macos to cut interactive shell startup cost, and remove
the duplicate `mise activate` now that shims on PATH suffice.

Swap the opam mise plugin to the upstream github source and wire up
ocamllsp plus ocamlformat in neovim.
