### PR TITLE
fix(plymouth): order splash after kernel module load on nvidia

### DIFF
--- a/modules/system/nixos/plymouth.nix
+++ b/modules/system/nixos/plymouth.nix
@@ -9,7 +9,17 @@
     };
 
     consoleLogLevel = 0;
+    initrd.systemd.enable = true;
     initrd.verbose = false;
+
+    # Wait for kernel modules (specifically nvidia-drm) before showing the
+    # splash. Without this ordering, plymouth-start races systemd-modules-load
+    # and opens simpledrm; nvidia-drm then takes the display ~2s later and
+    # plymouth's surface goes to a stale framebuffer, falling back to text.
+    initrd.systemd.services.plymouth-start = {
+      after = [ "systemd-modules-load.service" ];
+      wants = [ "systemd-modules-load.service" ];
+    };
     kernelParams = [
       "quiet"
       "loglevel=3"


### PR DESCRIPTION
On this host plymouth-start races systemd-modules-load in the
initrd. Plymouth wins the race, opens the simpledrm device, and
draws its splash there; nvidia-drm then takes over the display
roughly two seconds later, leaving plymouth's surface pointing
at a stale framebuffer. The visible symptom is the graphical
splash dropping back to plain text for the rest of boot.

Switching the initrd to systemd lets us express the ordering
directly: plymouth-start now waits for systemd-modules-load so
nvidia-drm is in place before any DRM device is opened, and the
splash renders against the real display from the start.
