### PR TITLE
feat(deadmau5): enable localsend for cross-device file sharing

### DIFF
--- a/modules/machines/deadmau5/system.nix
+++ b/modules/machines/deadmau5/system.nix
@@ -30,6 +30,11 @@
     openFirewall = true;
   };
 
+  programs.localsend = {
+    enable = true;
+    openFirewall = true;
+  };
+
   # Allow input group to create virtual input devices (for Sunshine gamepad/keyboard/mouse)
   # Set NVMe I/O scheduler to none (NVMe has internal scheduling, software scheduler adds CPU overhead)
   services.udev.extraRules = ''


### PR DESCRIPTION
Adds a convenient way to transfer files between deadmau5 and other
devices on the local network without relying on cloud services or
manually setting up SSH/SMB shares. Opens the required firewall ports
so peers can discover and connect to this host out of the box.
