### PR TITLE
chore(homebrew): rename casks to upstream-renamed names

### DIFF
--- a/modules/machines/workmac/system.nix
+++ b/modules/machines/workmac/system.nix
@@ -27,7 +27,7 @@
       cleanup = "none";
     };
     casks = [
-      "google-cloud-sdk"
+      "gcloud-cli"
     ];
   };
 

--- a/modules/system/meta/gui-darwin.nix
+++ b/modules/system/meta/gui-darwin.nix
@@ -8,7 +8,7 @@
   homebrew.casks = [
     "alfred"
     "claude"
-    "eloston-chromium"
+    "ungoogled-chromium"
     "ghostty"
     "karabiner-elements"
     "orbstack"


### PR DESCRIPTION
Homebrew renamed eloston-chromium to ungoogled-chromium and
google-cloud-sdk to gcloud-cli, causing deprecation warnings on every
darwin-rebuild. Update the cask references to silence the warnings.
