### PR TITLE
feat(zellij): surface claude-code status and integrate eilmeldung

### DIFF
--- a/bin/claude-status
+++ b/bin/claude-status
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-status"
+
+status_file() {
+  local session="${ZELLIJ_SESSION_NAME:-unknown}"
+  local pane="${ZELLIJ_PANE_ID:-0}"
+  echo "${CACHE_DIR}/${session}_${pane}"
+}
+
+cmd_set() {
+  local status="${1:?Usage: claude-status set <waiting|working|done>}"
+  case "$status" in
+    waiting|working|done) ;;
+    *) echo "Invalid status: $status" >&2; exit 1 ;;
+  esac
+
+  mkdir -p "$CACHE_DIR"
+  local file
+  file=$(status_file)
+  local tmp="${file}.tmp.$$"
+
+  cat > "$tmp" <<EOF
+session=${ZELLIJ_SESSION_NAME:-unknown}
+pane=${ZELLIJ_PANE_ID:-0}
+pid=${PPID}
+status=${status}
+timestamp=$(date +%s)
+EOF
+  mv -f "$tmp" "$file"
+}
+
+cmd_clear() {
+  local file
+  file=$(status_file)
+  rm -f "$file"
+}
+
+cmd_clean() {
+  [ -d "$CACHE_DIR" ] || return 0
+  for f in "$CACHE_DIR"/*; do
+    [ -f "$f" ] || continue
+    local pid
+    pid=$(grep '^pid=' "$f" 2>/dev/null | cut -d= -f2)
+    if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+      rm -f "$f"
+    fi
+  done
+}
+
+priority_of() {
+  case "$1" in
+    waiting) echo 0 ;;
+    done)    echo 1 ;;
+    working) echo 2 ;;
+    *)       echo 3 ;;
+  esac
+}
+
+icon_of() {
+  case "$1" in
+    waiting) echo "⏳" ;;
+    working) echo "⚙"  ;;
+    done)    echo "✓"  ;;
+  esac
+}
+
+cmd_query() {
+  local max_width=80
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --width) max_width="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  [ -d "$CACHE_DIR" ] || return 0
+
+  # Prune stale entries
+  cmd_clean
+
+  # Read all entries: "priority session status"
+  local entries=()
+  for f in "$CACHE_DIR"/*; do
+    [ -f "$f" ] || continue
+    local session status pid
+    session=$(grep '^session=' "$f" 2>/dev/null | cut -d= -f2)
+    status=$(grep '^status=' "$f" 2>/dev/null | cut -d= -f2)
+    pid=$(grep '^pid=' "$f" 2>/dev/null | cut -d= -f2)
+    [ -n "$session" ] && [ -n "$status" ] || continue
+    local pri
+    pri=$(priority_of "$status")
+    entries+=("${pri} ${session} ${status}")
+  done
+
+  [ ${#entries[@]} -eq 0 ] && return 0
+
+  # Sort by priority (ascending = highest priority first)
+  IFS=$'\n' sorted=($(printf '%s\n' "${entries[@]}" | sort -n)); unset IFS
+
+  # Build output with truncation
+  local sep=" | "
+  local sep_len=${#sep}
+  local result=""
+  local remaining=$max_width
+  local count=0
+  local total=${#sorted[@]}
+
+  for entry in "${sorted[@]}"; do
+    local pri session status
+    read -r pri session status <<< "$entry"
+    local icon
+    icon=$(icon_of "$status")
+    # "session:icon" — icon is multi-byte but 1-2 display columns
+    local icon_display_len=1
+    local colon_len=1
+    local min_entry_len=$((3 + 1 + colon_len + icon_display_len)) # "ses…:⚙"
+
+    if [ $count -gt 0 ]; then
+      # Check if we can fit at least a minimal entry with separator
+      local needed=$((sep_len + min_entry_len))
+      if [ $remaining -lt $needed ]; then
+        break
+      fi
+      remaining=$((remaining - sep_len))
+    fi
+
+    # Calculate available width for session name
+    local overhead=$((colon_len + icon_display_len))
+    local name_budget=$((remaining - overhead))
+
+    if [ $name_budget -lt 1 ]; then
+      break
+    fi
+
+    local display_name="$session"
+    if [ ${#session} -gt $name_budget ]; then
+      if [ $name_budget -ge 4 ]; then
+        # Truncate with ellipsis
+        local trunc_len=$((name_budget - 1))
+        display_name="${session:0:$trunc_len}…"
+      elif [ $name_budget -ge 1 ]; then
+        display_name="${session:0:$name_budget}"
+      fi
+    fi
+
+    local formatted="${display_name}:${icon}"
+    if [ $count -gt 0 ]; then
+      result="${result}${sep}${formatted}"
+    else
+      result="${formatted}"
+    fi
+
+    remaining=$((remaining - ${#display_name} - overhead))
+    count=$((count + 1))
+  done
+
+  echo "$result"
+}
+
+case "${1:-}" in
+  set)   shift; cmd_set "$@" ;;
+  clear) cmd_clear ;;
+  clean) cmd_clean ;;
+  query) shift; cmd_query "$@" ;;
+  *)
+    echo "Usage: claude-status {set|clear|clean|query}" >&2
+    echo "  set <waiting|working|done>  Update status for current instance" >&2
+    echo "  clear                       Remove entry for current instance" >&2
+    echo "  clean                       Remove all stale entries" >&2
+    echo "  query [--width N]           Format status output (default width: 80)" >&2
+    exit 1
+    ;;
+esac

--- a/config/fish/aliases/general.fish
+++ b/config/fish/aliases/general.fish
@@ -14,3 +14,4 @@ alias server 'ruby -run -e httpd . -p 8080'
 alias tf 'tail -f'
 alias vim nvim
 alias whereami 'curl http://remote-ip.herokuapp.com'
+alias z 'zellij'

--- a/config/fish/functions/wt.fish
+++ b/config/fish/functions/wt.fish
@@ -1,15 +1,12 @@
-# worktrunk shell integration for fish
-# Sources full integration from binary on first use.
-# Docs: https://worktrunk.dev/config/#shell-integration
-# Check: wt config show | Uninstall: wt config shell uninstall
-
 function wt
-    command wt config shell init fish | source
-    # Check both command exit code ($pipestatus[1]) and source exit code ($pipestatus[2])
-    # If source fails, the function isn't replaced and we'd infinite-loop calling ourselves
-    set -l wt_status $pipestatus[1]
-    set -l source_status $pipestatus[2]
-    test $wt_status -eq 0; or return $wt_status
-    test $source_status -eq 0; or return $source_status
-    wt $argv
+    switch $argv[1]
+        case switch
+            set -l workspace_path (command jjwt switch $argv[2..])
+            or return $status
+            if test -n "$workspace_path" -a -d "$workspace_path"
+                cd "$workspace_path"
+            end
+        case '*'
+            command jjwt $argv
+    end
 end

--- a/config/nvim/lua/lsp/sourcekit.lua
+++ b/config/nvim/lua/lsp/sourcekit.lua
@@ -1,0 +1,19 @@
+local M = {}
+
+function M.setup()
+  local helpers = require("lsp.helpers")
+
+  helpers.setup_lsp("sourcekit", {
+    autoformat = true,
+    cmd = { "sourcekit" },
+    filetypes = {
+      "swift",
+    },
+    on_attach_extra = function(client, _)
+      client.server_capabilities.documentFormattingProvider = true
+      client.server_capabilities.documentRangeFormattingProvider = true
+    end,
+  })
+end
+
+return M

--- a/config/zellij/layouts/onedark.kdl
+++ b/config/zellij/layouts/onedark.kdl
@@ -32,7 +32,7 @@ layout cwd="~/Projects" {
 
     format_left   "#[bg=$surface0,fg=$sapphire]#[bg=$sapphire,fg=$crust,bold] {session} #[bg=$surface0] {mode}#[bg=$surface0] {tabs}"
     format_center "{notifications}"
-    format_right  "#[bg=$surface0,fg=$peach]#[bg=$peach,fg=$crust]{command_weather} #[bg=$surface1,fg=$peach,bold] {command_weather_data}#[bg=$surface0,fg=$surface1]#[bg=$surface0,fg=$yellow]#[bg=$yellow,fg=$crust]{command_battery} #[bg=$surface1,fg=$yellow,bold] {command_battery_data}#[bg=$surface0,fg=$surface1]#[bg=$surface0,fg=$blue]#[bg=$blue,fg=$crust]󰃭 #[bg=$surface1,fg=$blue,bold] {datetime}#[bg=$surface0,fg=$surface1]"
+    format_right  "#[bg=$surface0,fg=$green]#[bg=$green,fg=$crust]{command_claude} #[bg=$surface1,fg=$green,bold] {command_claude_data}#[bg=$surface0,fg=$surface1]#[bg=$surface0,fg=$peach]#[bg=$peach,fg=$crust]{command_weather} #[bg=$surface1,fg=$peach,bold] {command_weather_data}#[bg=$surface0,fg=$surface1]#[bg=$surface0,fg=$yellow]#[bg=$yellow,fg=$crust]{command_battery} #[bg=$surface1,fg=$yellow,bold] {command_battery_data}#[bg=$surface0,fg=$surface1]#[bg=$surface0,fg=$blue]#[bg=$blue,fg=$crust]󰃭 #[bg=$surface1,fg=$blue,bold] {datetime}#[bg=$surface0,fg=$surface1]"
     format_space  "#[bg=$surface0]"
     border_enabled  "false"
     border_char     "─"
@@ -91,6 +91,16 @@ layout cwd="~/Projects" {
     command_battery_data_format    "{stdout}"
     command_battery_data_interval  "60"
     command_battery_data_rendermode "static"
+
+    command_claude_command    "bash -c ~/.dotfiles/config/zellij/scripts/claude-status.sh"
+    command_claude_format     "{stdout}"
+    command_claude_interval   "5"
+    command_claude_rendermode "static"
+
+    command_claude_data_command    "bash -c \"cat ${XDG_CACHE_HOME:-$HOME/.cache}/zjstatus/claude_status_data\""
+    command_claude_data_format     "{stdout}"
+    command_claude_data_interval   "5"
+    command_claude_data_rendermode "static"
 
     datetime          "{format}"
     datetime_format   "%Y-%m-%d 󰅐 %I:%M"

--- a/config/zellij/scripts/claude-status.sh
+++ b/config/zellij/scripts/claude-status.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/zjstatus"
+mkdir -p "$CACHE_DIR"
+
+output=$(claude-status query --width 40 2>/dev/null || true)
+
+if [ -n "$output" ]; then
+  echo "$output" > "$CACHE_DIR/claude_status_data"
+  echo ""
+else
+  # Clear cache file when no active sessions
+  > "$CACHE_DIR/claude_status_data"
+  echo ""
+fi

--- a/flake.lock
+++ b/flake.lock
@@ -101,8 +101,8 @@
     "cl-nix-lite": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs_4",
-        "systems": "systems_5",
+        "nixpkgs": "nixpkgs_2",
+        "systems": "systems_6",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -155,10 +155,34 @@
         "type": "github"
       }
     },
+    "eilmeldung": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779649568,
+        "narHash": "sha256-IHyPQkmH24yIRPs9BWcg4GxK7pUc8huZrdeGMXwoMlU=",
+        "owner": "endoze",
+        "repo": "eilmeldung",
+        "rev": "74b40c120b0011e06469bce76af5bacda488e74e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "endoze",
+        "ref": "fix/guard-glibc-includes-for-linux-only",
+        "repo": "eilmeldung",
+        "type": "github"
+      }
+    },
     "elephant": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "systems": "systems_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1775706155,
@@ -300,6 +324,24 @@
     },
     "flake-utils_2": {
       "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
         "systems": [
           "mac-app-util",
           "systems"
@@ -316,24 +358,6 @@
       "original": {
         "id": "flake-utils",
         "type": "indirect"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_7"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
       }
     },
     "flake-utils_4": {
@@ -390,6 +414,24 @@
         "type": "github"
       }
     },
+    "flake-utils_7": {
+      "inputs": {
+        "systems": "systems_11"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -414,7 +456,7 @@
     },
     "gomod2nix": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "matcha",
           "nixpkgs"
@@ -552,9 +594,9 @@
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
         "hyprwire": "hyprwire",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks",
-        "systems": "systems_3",
+        "systems": "systems_4",
         "xdph": "xdph"
       },
       "locked": {
@@ -709,8 +751,10 @@
         "hyprutils": "hyprutils_2",
         "hyprwayland-scanner": "hyprwayland-scanner_2",
         "hyprwire": "hyprwire_2",
-        "nixpkgs": "nixpkgs_3",
-        "systems": "systems_4"
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1777494113,
@@ -985,9 +1029,9 @@
       "inputs": {
         "cl-nix-lite": "cl-nix-lite",
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_6",
-        "systems": "systems_6",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_4",
+        "systems": "systems_7",
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
@@ -1006,9 +1050,11 @@
     },
     "matcha": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "gomod2nix": "gomod2nix",
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1777754143,
@@ -1027,7 +1073,7 @@
     },
     "monban": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_6",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1052,7 +1098,7 @@
         "cachyos-kernel-patches": "cachyos-kernel-patches",
         "flake-compat": "flake-compat_3",
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_9"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1779043214,
@@ -1091,11 +1137,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764242076,
-        "narHash": "sha256-sKoIWfnijJ0+9e4wRvIgm/HgE27bzwQxcEmo2J/gNpI=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fad6eac6077f03fe109c4d4eb171cf96791faa4",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {
@@ -1135,71 +1181,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
-        "lastModified": 1775710090,
-        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1772433332,
-        "narHash": "sha256-izhTDFKsg6KeVBxJS9EblGeQ8y+O8eCa6RcW874vxEc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "cf59864ef8aa2e178cccedbe2c178185b0365705",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
       "locked": {
         "lastModified": 1766736597,
         "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
@@ -1212,6 +1194,38 @@
         "owner": "nixos",
         "ref": "nixos-25.11",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1761236834,
+        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1732617236,
+        "narHash": "sha256-PYkz6U0bSEaEB1al7O1XsqVNeSNS+s3NVclJw7YC43w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
         "type": "github"
       }
     },
@@ -1233,54 +1247,6 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1732617236,
-        "narHash": "sha256-PYkz6U0bSEaEB1al7O1XsqVNeSNS+s3NVclJw7YC43w=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1761236834,
-        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_8": {
-      "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
         "lastModified": 1778930970,
         "narHash": "sha256-FqqcYr0c5in/HRL5bkRWykAGp/Q10Vj/zUiSr1P8URE=",
         "owner": "NixOS",
@@ -1291,6 +1257,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1342,6 +1324,7 @@
     "root": {
       "inputs": {
         "claude-desktop": "claude-desktop",
+        "eilmeldung": "eilmeldung",
         "elephant": "elephant",
         "home-manager": "home-manager",
         "hyprland": "hyprland",
@@ -1351,7 +1334,7 @@
         "monban": "monban",
         "nix-cachyos-kernel": "nix-cachyos-kernel",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_7",
         "nur": "nur",
         "shirase": "shirase",
         "sops-nix": "sops-nix",
@@ -1382,7 +1365,7 @@
     "shirase": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_7",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1454,6 +1437,21 @@
     },
     "systems_11": {
       "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_12": {
+      "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
@@ -1469,16 +1467,16 @@
     },
     "systems_2": {
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default-linux",
+        "repo": "default",
         "type": "github"
       }
     },
@@ -1514,6 +1512,21 @@
     },
     "systems_5": {
       "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
@@ -1527,7 +1540,7 @@
         "type": "github"
       }
     },
-    "systems_6": {
+    "systems_7": {
       "locked": {
         "lastModified": 1689347925,
         "narHash": "sha256-ozenz5bFe1UUqOn7f60HRmgc01BgTGIKZ4Xl+HbocGQ=",
@@ -1539,21 +1552,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default-darwin",
-        "type": "github"
-      }
-    },
-    "systems_7": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     },
@@ -1589,7 +1587,7 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1766000401,
@@ -1607,7 +1605,7 @@
     },
     "treefmt-nix_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1766000401,
@@ -1628,8 +1626,10 @@
         "elephant": [
           "elephant"
         ],
-        "nixpkgs": "nixpkgs_11",
-        "systems": "systems_11"
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_12"
       },
       "locked": {
         "lastModified": 1777789924,

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -11,13 +12,17 @@
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    mac-app-util = {
-      url = "github:hraban/mac-app-util";
-      # Don't follow nixpkgs - let mac-app-util use its own pinned version
-      # to avoid SBCL/CL build incompatibilities
+
+    claude-desktop = {
+      url = "github:k3d3/claude-desktop-linux-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
-    nur = {
-      url = "github:nix-community/NUR";
+    eilmeldung = {
+      url = "github:endoze/eilmeldung/fix/guard-glibc-includes-for-linux-only";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    elephant = {
+      url = "github:abenz1267/elephant";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     hyprland = {
@@ -27,33 +32,40 @@
     };
     hyprpaper = {
       url = "github:hyprwm/hyprpaper";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
-    nix-cachyos-kernel = {
-      url = "github:xddxdd/nix-cachyos-kernel/release";
-      # Do not override nixpkgs input to avoid version mismatches
+    mac-app-util = {
+      url = "github:hraban/mac-app-util";
+      # Don't follow nixpkgs - let mac-app-util use its own pinned version
+      # to avoid SBCL/CL build incompatibilities
     };
-    sops-nix = {
-      url = "github:Mic92/sops-nix";
+    matcha = {
+      url = "github:endoze/matcha/fix/scard-cgo-enabled";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     monban = {
       url = "git+ssh://git@github.com/endoze/monban";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nix-cachyos-kernel = {
+      url = "github:xddxdd/nix-cachyos-kernel/release";
+      # Do not override nixpkgs input to avoid version mismatches
+    };
+    nur = {
+      url = "github:nix-community/NUR";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     shirase = {
       url = "git+ssh://git@github.com/endoze/shirase";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    claude-desktop = {
-      url = "github:k3d3/claude-desktop-linux-flake";
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    matcha = {
-      url = "github:endoze/matcha/fix/scard-cgo-enabled";
-    };
-    elephant.url = "github:abenz1267/elephant";
     walker = {
       url = "github:abenz1267/walker";
+      inputs.nixpkgs.follows = "nixpkgs";
       inputs.elephant.follows = "elephant";
     };
   };

--- a/modules/home/common/eilmeldung.nix
+++ b/modules/home/common/eilmeldung.nix
@@ -1,0 +1,30 @@
+{ config, options, pkgs, lib, sourceRoot, userConfig, inputs, ... }:
+
+let hasSops = options ? sops;
+in
+{
+  imports = [ inputs.eilmeldung.homeManager.default ];
+
+  config = lib.mkMerge ([
+    {
+      programs.eilmeldung = {
+        enable = true;
+        package = inputs.eilmeldung.packages.${pkgs.stdenv.hostPlatform.system}.eilmeldung;
+      };
+    }
+  ] ++ lib.optional hasSops {
+    sops = {
+      age.keyFile = "${userConfig.homeDirectory}/.config/sops/age/keys.txt";
+      defaultSopsFile = sourceRoot + "/secrets/shared.enc.yaml";
+
+      secrets."miniflux-token" = { };
+    };
+
+    programs.eilmeldung.settings.login_setup = {
+      login_type = "direct_token";
+      provider = "miniflux";
+      url = "https://miniflux.kahdu.org/";
+      token = "cmd:cat ${config.sops.secrets."miniflux-token".path}";
+    };
+  });
+}

--- a/modules/home/common/zellij.nix
+++ b/modules/home/common/zellij.nix
@@ -5,6 +5,10 @@
     zellij
   ];
 
+  home.file = {
+    ".local/bin/claude-status".source = "${sourceRoot}/bin/claude-status";
+  };
+
   xdg.configFile = {
     "zellij".source = config.lib.file.mkOutOfStoreSymlink "${userConfig.dotfilesPath}/config/zellij";
   };

--- a/modules/home/meta/cli.nix
+++ b/modules/home/meta/cli.nix
@@ -6,24 +6,25 @@
   imports = [
     ../common/bat.nix
     ../common/databases.nix
+    ../common/eilmeldung.nix
     ../common/fastfetch.nix
     ../common/fish.nix
     ../common/git.nix
+    ../common/hn-tui.nix
     ../common/jujutsu.nix
-    ../common/lua.nix
     ../common/lsd.nix
+    ../common/lua.nix
+    ../common/matcha.nix
     ../common/mise.nix
     ../common/neovim.nix
     ../common/ruby.nix
     ../common/selene.nix
-    ../common/sqruff.nix
     ../common/shell-ai.nix
+    ../common/sqruff.nix
     ../common/starship.nix
     ../common/tmux.nix
     ../common/weechat.nix
     ../common/zellij.nix
-    ../common/hn-tui.nix
-    ../common/matcha.nix # disabled: upstream build broken (scard CGO mismatch)
   ];
 
   home.packages = with pkgs; [

--- a/secrets/shared.enc.yaml
+++ b/secrets/shared.enc.yaml
@@ -1,5 +1,6 @@
 soju-password: ENC[AES256_GCM,data:1woRMgeZmConG0gK,iv:cyxIHf9aQF4tt1KfTUIe/kkNKktptszxsXBTTNRxxJA=,tag:k+2GLEqrwiXWJTjeOStPfA==,type:str]
 attic-admin-key: ENC[AES256_GCM,data:I10Qw1uBk0vf9aEo0tlmA0xctBI8N3aRQzG2zIniL3ZHtw2FknZv8dhYprmwP3qYY1tKtbdQsPkZ1FWmQYw8z9EElDSbrFKe+8cDX7tR4lplYFjh4xMOOqzDEoDeNiadwRb7DTqOICys13NjPSjzJ7m8ioloz6RfwQyCFhsCAEJa3vr1sKYIxy2DSHWgH1GIOBV+24noIo80eypSSXgxFIlZn4NOFlD5ZBnoLzwVCj/52mw6p/CYRb+C0KKPEb9vN1vqNdp0GSPhGyRBvSPq9E2LWaWqUaKibvUnCMW/Y6Ha/9O8kZSiv+rdqLUIVj/nnyumeVF+V/4R07sJ/qeRph6gCec=,iv:O8Lhna1JGII2+ZFgqAZTPdlfi87bcJ8WYsBKz+Xfn5w=,tag:5v8LgWSsc+NoeoZJmGaR5w==,type:str]
+miniflux-token: ENC[AES256_GCM,data:dw3OP593H9oO0f3kziTzGeeXdEJs40oaWb7WVLIHAm4i1B+uVHyWk3Fef/45zUvQkBEQNdJFEsHHk3+pnZkQ/A==,iv:s2KccE/x4K9i+EpDti53bZ+uOxYSrXudNdIdf7B5AX8=,tag:svf0g/PaSJC/hsXSqwLfTg==,type:str]
 sops:
     age:
         - recipient: age1k86acr23u57gppgvuawe6usssm9njurknzdjue2lstuvscg4uakqkcu7p6
@@ -47,7 +48,7 @@ sops:
             NDh5bmt0NHJMV1Fuc1lBbjJjYUZGV28KPJTKEbKv3kRZvYY3Ww2QU3Sn3gDj3jlV
             7Ieiiy5DEZE/y9Wz9NWI85TKDFti8V9e7S9gXXN7UeuEWXtnTT6HfA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-21T14:06:04Z"
-    mac: ENC[AES256_GCM,data:e7fZFGgtTAHFg98zRQvga6CN1pzkpW2y3nXf76nOe9pvxD7r6P06Ut3mclgXi1ToBD/s7k3KJOnpReZDIcwGPocXhwJIOBNTrDstBk4at+0cxLYAysTrj4R1geU/lB3I+Nt8FGkpvFzUnrCLUY0qMek65He77u8dEFRQuG5u/+M=,iv:CpAc44UJyRDxamVKic0vUpRSrwYFVyJanjc8Qk0V6JE=,tag:8H+3gRbItrWgwDL0rDFe+Q==,type:str]
+    lastmodified: "2026-05-24T18:23:59Z"
+    mac: ENC[AES256_GCM,data:To2BUCmr2rB39WI+JqIH7VJpyD09BLyFxMrRUtF3n0qLD90Vh7s6tbdzO+eZSLg1kV1vXJHGkhBoGC+VH2pfVNyNzCnaaBuYnux0buyzh3aipmZgWGZK4TptSU7bfUARZ1q0kx6k3zFOY+zkPQS+6OQYb9eUfCcVMOb2BlRr/mo=,iv:tgkLgZxL9cQYn5+G0xEeF3zHgphoQLm/t3+DXRHkugs=,tag:rbaUPH/KKszB0pYEoot+Tg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Track per-pane Claude Code activity (waiting/working/done) via a small
helper script and render it in the zellij status bar so long-running
sessions across panes are visible at a glance without switching to
each one. Also wire up the eilmeldung RSS reader with miniflux token
loaded through sops, switch the wt fish function to jjwt-based
worktree switching, add a sourcekit LSP config for Swift, and clean
up flake inputs so more dependencies follow the root nixpkgs.
