### PR TITLE
perf(docker): cache nix store closure across CI runs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
@@ -56,7 +56,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Build and push Docker image with Buildx (don't push on PR)
+      # Build and push Docker image with Buildx (don't push on PR).
+      # We always `load` the image into the local docker daemon so the
+      # post-build attic push step can `docker run` it.
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
@@ -64,7 +66,33 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          secrets: |
+            "attic-netrc=${{ secrets.ATTIC_NETRC }}"
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
+
+      # Push CI-built paths back to attic so they benefit other machines
+      # and future CI runs. Attic does not implement the standard nix
+      # HTTP binary cache write protocol (PUT /nar/...), so we use the
+      # attic CLI — built inside the throwaway container via nix and
+      # discarded with it. The token is passed as an env var; nothing
+      # touches disk on the runner and nothing lands in any image layer.
+      - name: Push closure back to attic
+        env:
+          ATTIC_NETRC: ${{ secrets.ATTIC_NETRC }}
+        run: |
+          IMAGE="$(printf '%s\n' '${{ steps.meta.outputs.tags }}' | head -n1)"
+          TOKEN=$(printf '%s' "$ATTIC_NETRC" | awk '/^password/ {print $2}')
+          docker run --rm --user 0 \
+            -e ATTIC_TOKEN="$TOKEN" \
+            --entrypoint sh "$IMAGE" -c '
+              set -e
+              export PATH=/root/.nix-profile/bin:$PATH
+              ATTIC=$(nix build --no-link --print-out-paths nixpkgs#attic-client)
+              export PATH="$ATTIC/bin:$PATH"
+              attic login main https://cache.kahdu.org/ "$ATTIC_TOKEN"
+              attic push main:main $(nix-store -qR /home/endoze/.hm-activation)
+            '

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,34 @@
 FROM nixos/nix:latest
 
-RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
+# nix.conf with no reference to private cache. Substituter + key are
+# supplied only via --option flags during the secret-mounted RUN, so
+# they never persist in any layer.
+RUN printf '%s\n' \
+      'experimental-features = nix-command flakes' \
+      'require-sigs = false' \
+      >> /etc/nix/nix.conf
 
-COPY . /dotfiles
+COPY . /home/endoze/.dotfiles
+WORKDIR /home/endoze/.dotfiles
 
-WORKDIR /dotfiles
+# Build user setup + home-manager activation. The netrc is mounted as
+# tmpfs for this RUN only — it is never written to a layer. Substituter
+# URL and public key are passed via --option, so the resulting image
+# carries zero reference to the private cache host.
+RUN --mount=type=secret,id=attic-netrc,target=/etc/nix/attic-netrc \
+    nix build .#packages.x86_64-linux.dockerUserSetup -o /tmp/user-setup \
+        --option netrc-file /etc/nix/attic-netrc \
+        --option extra-substituters https://cache.kahdu.org/main \
+        --option extra-trusted-public-keys main:ch1Il2WBscgvKTDg00wIqQCT/wSyqlA7lD0n2m2VkOg= \
+ && /tmp/user-setup/bin/setup-user \
+ && nix build .#homeConfigurations.docker.activationPackage \
+        -o /home/endoze/.hm-activation \
+        --option netrc-file /etc/nix/attic-netrc \
+        --option extra-substituters https://cache.kahdu.org/main \
+        --option extra-trusted-public-keys main:ch1Il2WBscgvKTDg00wIqQCT/wSyqlA7lD0n2m2VkOg= \
+ && chown -R 1000:100 /home/endoze \
+ && chown -R 1000:100 /nix
 
-# Build user setup script and create user via Nix
-RUN nix build .#packages.x86_64-linux.dockerUserSetup -o /tmp/user-setup && \
-    /tmp/user-setup/bin/setup-user
-
-# Build home-manager activation as root (has nix store permissions)
-RUN nix build .#homeConfigurations.docker.activationPackage -o /home/endoze/.hm-activation && \
-    chown -R 1000:100 /home/endoze && \
-    chown -R 1000:100 /nix
-
-# Copy dotfiles for the user
-RUN cp -r /dotfiles /home/endoze/.dotfiles && \
-    chown -R 1000:100 /home/endoze/.dotfiles
-
-# Switch to endoze and activate home-manager
 USER endoze
 ENV USER=endoze
 WORKDIR /home/endoze


### PR DESCRIPTION
The docker image build was taking multiple hours because every CI run
rebuilt the entire Rust-heavy home-manager closure from source. Cache
the exported store closure keyed on flake.lock and import it at the
start of subsequent builds so only inputs that actually changed get
rebuilt. Also fuse the dotfiles copy, user setup, activation build,
and ownership fixes into a single layer to avoid a second full walk
of /nix during chown.
