### PR TITLE
chore(home): add jj bookmark aliases and skip mise checkPhase

### DIFF
--- a/modules/home/common/jujutsu.nix
+++ b/modules/home/common/jujutsu.nix
@@ -22,6 +22,8 @@
 
       aliases = {
         shortlog = [ "log" "-n" "10" ];
+        bc = [ "bookmark" "create" ];
+        bs = [ "bookmark" "set" ];
       };
 
       signing = lib.mkIf (userConfig.gpgKey != "") {

--- a/modules/home/common/mise.nix
+++ b/modules/home/common/mise.nix
@@ -1,6 +1,14 @@
 { config, pkgs, lib, userConfig, ... }:
 
 {
+  # Skip mise's checkPhase to avoid lengthy local rebuilds (e.g. aws-lc-sys)
+  # when cache.nixos.org doesn't yet have a substitute for the pinned version.
+  nixpkgs.overlays = [
+    (final: prev: {
+      mise = prev.mise.overrideAttrs (_: { doCheck = false; });
+    })
+  ];
+
   home.packages = with pkgs; [
     mise
   ];


### PR DESCRIPTION
The jj bookmark create/set commands are typed often enough to warrant
short aliases. The mise checkPhase override avoids lengthy local
rebuilds of heavy dependencies like aws-lc-sys when cache.nixos.org
lacks a substitute for the pinned version.
