### PR TITLE
feat(jujutsu): default jj log to show all revisions

### DIFF
--- a/modules/home/common/jujutsu.nix
+++ b/modules/home/common/jujutsu.nix
@@ -24,6 +24,7 @@
         shortlog = [ "log" "-n" "10" ];
         bc = [ "bookmark" "create" ];
         bs = [ "bookmark" "set" ];
+        some = [ "util" "exec" "--" "sh" "-c" "jj git fetch && jj new master" ];
       };
 
       signing = lib.mkIf (userConfig.gpgKey != "") {
@@ -40,6 +41,7 @@
 
       revsets = {
         immutable-heads = ''remote_bookmarks(exact:"main") | remote_bookmarks(exact:"master")'';
+        log = "all()";
       };
 
       revset-aliases = {


### PR DESCRIPTION
Override the default log revset so `jj log` displays the full history
instead of just the trunk-relative view, making it easier to see all
local work at a glance.
