### PR TITLE
chore: docker CI rewrite + dev env cleanup

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,10 +37,71 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      # Install upstream Nix on the runner. We use cachix/install-nix-action
+      # rather than DeterminateSystems' installer because the latter ships
+      # Determinate Nix, which manages its own /etc/nix/netrc for FlakeHub
+      # auth and does not honor extra-conf's `netrc-file` directive — both
+      # of which conflict with our attic auth setup.
+      - name: Install Nix
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+        with:
+          extra_nix_config: |
+            extra-substituters = https://cache.kahdu.org/main
+            extra-trusted-public-keys = main:ch1Il2WBscgvKTDg00wIqQCT/wSyqlA7lD0n2m2VkOg=
+            netrc-file = /etc/nix/netrc
+
+      # Write the attic netrc so the nix daemon (root) can authenticate
+      # against cache.kahdu.org when substituting. umask 077 ensures any
+      # partial write stays mode 600; the final chmod is belt-and-braces.
+      - name: Configure attic netrc
+        env:
+          ATTIC_NETRC: ${{ secrets.ATTIC_NETRC }}
+        run: |
+          umask 077
+          printf '%s\n' "$ATTIC_NETRC" | sudo tee /etc/nix/netrc > /dev/null
+          sudo chmod 600 /etc/nix/netrc
+
+      # Build the home-manager activation closure on the runner. On a warm
+      # attic this is ~30-60s of pure substitution. On a cold attic (e.g.
+      # the first build after a flake.lock bump that introduces new
+      # derivation hashes) this pays the rebuild cost ONCE so the subsequent
+      # attic push warms the cache for the docker buildkit step and all
+      # future runs.
+      - name: Build home-manager closure
+        id: closure
+        run: |
+          out=$(nix build .#homeConfigurations.docker.activationPackage \
+            --no-link --print-out-paths)
+          echo "path=$out" >> "$GITHUB_OUTPUT"
+
+      # Push the just-built closure to attic from the runner. No docker
+      # round-trip. This warms attic for every other machine and for the
+      # buildkit step below (when present). Pushing from PRs too keeps
+      # master fast when a PR introduces a new derivation hash.
+      #
+      # `::add-mask::` registers the parsed token as a masked value so
+      # nothing downstream can accidentally surface it in logs even if a
+      # tool tries to print it. GitHub already masks the full netrc blob;
+      # this masks the token in isolation too.
+      - name: Push closure to attic
+        env:
+          ATTIC_NETRC: ${{ secrets.ATTIC_NETRC }}
+        run: |
+          ATTIC=$(nix build --no-link --print-out-paths nixpkgs#attic-client)
+          TOKEN=$(printf '%s' "$ATTIC_NETRC" | awk '/^password/ {print $2}')
+          echo "::add-mask::$TOKEN"
+          "$ATTIC/bin/attic" login main https://cache.kahdu.org/ "$TOKEN"
+          nix-store -qR "${{ steps.closure.outputs.path }}" \
+            | xargs "$ATTIC/bin/attic" push main:main
+
+      # Everything below this point only runs when publishing to GHCR
+      # (i.e. push events on master). PRs end here: the closure built and
+      # cached above is sufficient validation that the build is green.
+
       - name: Setup Docker buildx
+        if: github.event_name != 'pull_request'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
@@ -54,48 +115,36 @@ jobs:
       # `annotations` output (default level = manifest) is passed to the
       # build step below so GHCR can read the image description from the
       # OCI manifest. We do NOT widen the level to `index`: with
-      # `load: true` the build exports as Docker image format (no index
-      # wrapper) and buildx rejects index annotations in that case.
+      # `push: true` (no `load: true`) the build exports as OCI image
+      # format, and buildx rejects index annotations there too.
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
+        if: github.event_name != 'pull_request'
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Build and push Docker image with Buildx (don't push on PR).
-      # We always `load` the image into the local docker daemon so the
-      # post-build attic push step can `docker run` it.
+      # Build and push Docker image with Buildx. With `load: true` removed
+      # buildx exports straight to the registry — no local docker daemon
+      # round-trip, no ~1.5 GB tarball staging. The closure was already
+      # pushed to attic above, so the in-container `nix build` substitutes
+      # the full store from cache.kahdu.org in seconds.
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
+        if: github.event_name != 'pull_request'
         id: build-and-push
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          load: true
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
           secrets: |
             "attic-netrc=${{ secrets.ATTIC_NETRC }}"
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
-
-      # Resolve the actual registry manifest digest. We can't use
-      # `steps.build-and-push.outputs.digest` directly: when the build
-      # step is configured with `push: true` AND `load: true` (so the
-      # attic step further down can `docker run` the image), buildx
-      # reports the buildkit-local digest, which does NOT match the
-      # OCI manifest digest published to GHCR. Inspecting the tag via
-      # imagetools gives us the registry digest unambiguously.
-      - name: Resolve registry digest
-        if: github.event_name != 'pull_request'
-        id: registry-digest
-        run: |
-          IMAGE="$(printf '%s\n' '${{ steps.meta.outputs.tags }}' | head -n1)"
-          DIGEST=$(docker buildx imagetools inspect "$IMAGE" --format '{{.Manifest.Digest}}')
-          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 
       # Generate a SLSA build provenance attestation for the pushed image.
       # The attestation is signed by Sigstore/Fulcio using this workflow's
@@ -103,33 +152,15 @@ jobs:
       # does NOT appear as a separate `.sig`-style version in the package
       # UI. Verifiable with:
       #   gh attestation verify oci://ghcr.io/endoze/dotfiles:<tag> --owner endoze
+      #
+      # `steps.build-and-push.outputs.digest` is the real OCI manifest
+      # digest now that `load: true` is gone (the previous workaround that
+      # re-resolved the digest via `docker buildx imagetools` is no longer
+      # needed).
       - name: Attest build provenance
         if: github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.registry-digest.outputs.digest }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
           push-to-registry: true
-
-      # Push CI-built paths back to attic so they benefit other machines
-      # and future CI runs. Attic does not implement the standard nix
-      # HTTP binary cache write protocol (PUT /nar/...), so we use the
-      # attic CLI — built inside the throwaway container via nix and
-      # discarded with it. The token is passed as an env var; nothing
-      # touches disk on the runner and nothing lands in any image layer.
-      - name: Push closure back to attic
-        env:
-          ATTIC_NETRC: ${{ secrets.ATTIC_NETRC }}
-        run: |
-          IMAGE="$(printf '%s\n' '${{ steps.meta.outputs.tags }}' | head -n1)"
-          TOKEN=$(printf '%s' "$ATTIC_NETRC" | awk '/^password/ {print $2}')
-          docker run --rm --user 0 \
-            -e ATTIC_TOKEN="$TOKEN" \
-            --entrypoint sh "$IMAGE" -c '
-              set -e
-              export PATH=/root/.nix-profile/bin:$PATH
-              ATTIC=$(nix build --no-link --print-out-paths nixpkgs#attic-client)
-              export PATH="$ATTIC/bin:$PATH"
-              attic login main https://cache.kahdu.org/ "$ATTIC_TOKEN"
-              attic push main:main $(nix-store -qR /home/endoze/.hm-activation)
-            '

--- a/bin/claude-status
+++ b/bin/claude-status
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-status"
+STALE_AFTER=3600  # seconds; entries older than this are pruned by `clean`
 
 status_file() {
   local session="${ZELLIJ_SESSION_NAME:-unknown}"
@@ -39,11 +40,16 @@ cmd_clear() {
 
 cmd_clean() {
   [ -d "$CACHE_DIR" ] || return 0
+  # Prune by timestamp, not pid: the pid stored by `set` is the hook
+  # subshell's PPID, which exits as soon as the hook finishes. A pid-based
+  # check would delete entries seconds after they're written.
+  local now
+  now=$(date +%s)
   for f in "$CACHE_DIR"/*; do
     [ -f "$f" ] || continue
-    local pid
-    pid=$(grep '^pid=' "$f" 2>/dev/null | cut -d= -f2)
-    if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+    local ts
+    ts=$(grep '^timestamp=' "$f" 2>/dev/null | cut -d= -f2)
+    if [ -z "$ts" ] || [ $((now - ts)) -gt "$STALE_AFTER" ]; then
       rm -f "$f"
     fi
   done

--- a/config/fish/completions/jjwt.fish
+++ b/config/fish/completions/jjwt.fish
@@ -1,0 +1,2 @@
+complete --keep-order --exclusive --command jjwt --arguments "(COMPLETE=fish jjwt -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
+complete --keep-order --exclusive --command wt --arguments "(COMPLETE=fish jjwt -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"

--- a/config/fish/completions/wt.fish
+++ b/config/fish/completions/wt.fish
@@ -1,2 +1,0 @@
-# worktrunk completions for fish
-complete --keep-order --exclusive --command wt --arguments "(test -n \"\$WORKTRUNK_BIN\"; or set -l WORKTRUNK_BIN (type -P wt 2>/dev/null); and COMPLETE=fish \$WORKTRUNK_BIN -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"

--- a/config/fish/conf.d/02-telemetry-optout.fish
+++ b/config/fish/conf.d/02-telemetry-optout.fish
@@ -1,0 +1,14 @@
+# Disable telemetry, analytics, and update-nag prompts across CLI tools.
+
+set -gx HOMEBREW_NO_ANALYTICS 1
+set -gx HOMEBREW_NO_ENV_HINTS 1
+set -gx CHECKPOINT_DISABLE 1
+set -gx DOCKER_CLI_HINTS false
+set -gx DOCKER_SCAN_SUGGEST false
+set -gx DOTNET_CLI_TELEMETRY_OPTOUT 1
+set -gx YARN_ENABLE_TELEMETRY 0
+set -gx DO_NOT_TRACK 1
+set -gx NPM_CONFIG_UPDATE_NOTIFIER false
+set -gx NPM_CONFIG_FUND false
+set -gx GH_NO_UPDATE_NOTIFIER 1
+set -gx MISE_DISABLE_HINTS 1

--- a/config/fish/functions/wt.fish
+++ b/config/fish/functions/wt.fish
@@ -1,10 +1,25 @@
 function wt
     switch $argv[1]
-        case switch
-            set -l workspace_path (command jjwt switch $argv[2..])
+        case switch remove
+            set -l __wt_out (command jjwt $argv[1] $argv[2..])
             or return $status
-            if test -n "$workspace_path" -a -d "$workspace_path"
-                cd "$workspace_path"
+            set -l __wt_cd ""
+            set -l __wt_exec ""
+            for line in $__wt_out
+                set -l prefix (string sub -l 3 -- $line)
+                if test "$prefix" = "cd:"
+                    set __wt_cd (string sub -s 4 -- $line)
+                else if test (string sub -l 5 -- $line) = "exec:"
+                    set __wt_exec (string sub -s 6 -- $line)
+                else if test -z "$__wt_cd" -a -n "$line" -a -d "$line"
+                    set __wt_cd $line
+                end
+            end
+            if test -n "$__wt_cd" -a -d "$__wt_cd"
+                cd "$__wt_cd"
+            end
+            if test -n "$__wt_exec"
+                eval $__wt_exec
             end
         case '*'
             command jjwt $argv

--- a/config/zellij/layouts/onedark.kdl
+++ b/config/zellij/layouts/onedark.kdl
@@ -39,7 +39,9 @@ layout cwd="~/Projects" {
     border_format   "#[bg=$surface0]{char}"
     border_position "top"
 
-    hide_frame_for_single_pane "true"
+    // Disabled: triggers rapid pane-frame toggle flicker
+    // (zjstatus issue #174). Re-enable only if upstream fixes it.
+    hide_frame_for_single_pane "false"
 
     mode_normal        "#[bg=$green,fg=$crust,bold] NORMAL#[bg=$surface0,fg=$green]"
     mode_tmux          "#[bg=$mauve,fg=$crust,bold] TMUX#[bg=$surface0,fg=$mauve]"

--- a/config/zellij/scripts/claude-status.sh
+++ b/config/zellij/scripts/claude-status.sh
@@ -4,11 +4,11 @@ mkdir -p "$CACHE_DIR"
 
 output=$(claude-status query --width 40 2>/dev/null || true)
 
-if [ -n "$output" ]; then
-  echo "$output" > "$CACHE_DIR/claude_status_data"
-  echo ""
-else
-  # Clear cache file when no active sessions
-  > "$CACHE_DIR/claude_status_data"
-  echo ""
-fi
+# Write atomically so the zjstatus `cat` reader never observes a
+# half-written or momentarily-truncated file (which would manifest as a
+# flicker/strobe in the status bar).
+target="$CACHE_DIR/claude_status_data"
+tmp="${target}.tmp.$$"
+printf '%s' "$output" > "$tmp"
+mv -f "$tmp" "$target"
+echo ""

--- a/modules/home/common/mise.nix
+++ b/modules/home/common/mise.nix
@@ -1,29 +1,10 @@
 { config, pkgs, lib, userConfig, ... }:
 
 {
-  # Skip mise's checkPhase to avoid lengthy local rebuilds (e.g. aws-lc-sys)
-  # when cache.nixos.org doesn't yet have a substitute for the pinned version.
-  nixpkgs.overlays = [
-    (final: prev: {
-      mise = prev.mise.overrideAttrs (_: { doCheck = false; });
-    })
-  ];
-
   home.packages = with pkgs; [
     mise
   ];
 
-  # Configure mise environment variables
-  home.sessionVariables = {
-    # Keep mise data outside of nix store for mutability
-    MISE_DATA_DIR = "${config.home.homeDirectory}/.local/share/mise";
-  };
-
   # Link mise configuration with out-of-store symlink for live updates
   xdg.configFile."mise".source = config.lib.file.mkOutOfStoreSymlink "${userConfig.dotfilesPath}/config/mise";
-
-  # Ensure mise data directory exists with proper permissions
-  home.activation.createMiseDataDir = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    mkdir -p $HOME/.local/share/mise
-  '';
 }

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -11,12 +11,6 @@
     ".rustfmt.toml".source = "${sourceRoot}/config/rustfmt.toml";
   };
 
-  home.sessionVariables = {
-    EDITOR = "nvim";
-    VISUAL = "nvim";
-    PAGER = "less";
-  };
-
   programs = {
     home-manager.enable = true;
 


### PR DESCRIPTION
docker-publish.yml: install nix on the runner, build the home-manager
activation closure there, and push to attic directly. PRs skip the
buildkit step entirely (the runner build is sufficient validation).
Master push uses push: true only — no more load: true round-tripping
~1.5 GB through the docker daemon, and no Resolve registry digest
workaround. Target: ~3m PRs, ~7-9m master, down from ~14m.

mise: drop the doCheck = false overlay, MISE_DATA_DIR session var, and
createMiseDataDir activation entry. The overlay changed mise's
derivation hash and forced from-source rebuilds on every flake bump,
which pushed the first CI build of a new mise version to 38+ minutes.
Stock mise caches fine.

wt: switch from a worktrunk shim to a jjwt wrapper. Handle switch and
remove subcommands, parsing cd:/exec: output lines so the function can
both change directory and run follow-up commands. Replace the wt fish
completion with a jjwt completion that also drives wt.

fish: add a conf.d entry exporting telemetry opt-outs for homebrew,
docker, .NET, yarn, npm, gh, mise, terraform checkpoint, and a generic
DO_NOT_TRACK.
