### PR TITLE
Fix eww systray watcher losing the dbus name race

### DIFF
--- a/config/hypr/configs/startup.conf
+++ b/config/hypr/configs/startup.conf
@@ -1,4 +1,5 @@
 # vim: ft=hyprlang
 
-exec-once = eww open bar
+# eww is started via systemd (modules/home/linux/eww.nix) so SNI clients can
+# order themselves After=eww.service and avoid racing for the systray watcher.
 exec-once = echo 'Xft.dpi: 192' | xrdb -merge

--- a/modules/home/linux/eww.nix
+++ b/modules/home/linux/eww.nix
@@ -1,5 +1,42 @@
 { config, pkgs, lib, sourceRoot, userConfig, ... }:
 
+let
+  # eww 0.6.0's StatusNotifierWatcher silently queues if another process claims
+  # the org.kde.StatusNotifierWatcher dbus name first (watcher.rs:200 omits
+  # DoNotQueue). When that happens, eww's host registration goes to the squatter's
+  # watcher, and after the squatter dies eww owns the name but with empty internal
+  # state -- tray icons never display. This start script proves eww won the race
+  # before returning, so units ordered After=eww.service can rely on a working tray.
+  eww-start = pkgs.writeShellScript "eww-start" ''
+    set -euo pipefail
+
+    # eww-daemon.service is Type=simple, so systemd marks it active the moment
+    # the process is forked -- before the IPC socket is up. Ping the daemon
+    # until it answers before trying to open the bar.
+    for _ in $(seq 1 100); do
+      if ${pkgs.eww}/bin/eww ping >/dev/null 2>&1; then break; fi
+      sleep 0.1
+    done
+
+    ${pkgs.eww}/bin/eww open bar
+
+    # Wait until eww owns both org.kde.StatusNotifierWatcher and a
+    # StatusNotifierHost-* name on the same connection (== eww won the race).
+    for _ in $(seq 1 100); do
+      watcher_pid=$(${pkgs.systemd}/bin/busctl --user list 2>/dev/null \
+        | ${pkgs.gawk}/bin/awk '$1 == "org.kde.StatusNotifierWatcher" { print $2; exit }')
+      host_pid=$(${pkgs.systemd}/bin/busctl --user list 2>/dev/null \
+        | ${pkgs.gawk}/bin/awk '/^org\.freedesktop\.StatusNotifierHost-/ { print $2; exit }')
+      if [[ -n "$watcher_pid" ]] && [[ "$watcher_pid" = "$host_pid" ]]; then
+        exit 0
+      fi
+      sleep 0.1
+    done
+
+    echo "eww-start: timeout waiting for eww to claim StatusNotifierWatcher" >&2
+    exit 1
+  '';
+in
 {
   home.packages = with pkgs; [
     eww
@@ -9,5 +46,55 @@
 
   xdg.configFile = {
     "eww".source = config.lib.file.mkOutOfStoreSymlink "${userConfig.dotfilesPath}/config/eww";
+  };
+
+  # Run the daemon in foreground so its stdout/stderr land in the journal
+  # (journalctl --user -u eww-daemon). Without --no-daemonize, eww forks into
+  # the background and systemd loses both lifecycle control and log visibility.
+  #
+  # Ordering: After=graphical-session.target so we don't force a target restart
+  # at switch-to-configuration time. WantedBy+After is fine -- Wants= doesn't
+  # block target activation, so the target reaches active first, then eww
+  # starts. All SNI client units (nm-applet, blueman-applet, sunshine) are
+  # likewise After=graphical-session.target, so there's no cycle.
+  systemd.user.services.eww-daemon = {
+    Unit = {
+      Description = "ElKowar's wacky widgets - daemon";
+      Documentation = "https://github.com/elkowar/eww";
+      PartOf = [ "graphical-session.target" ];
+      After = [ "graphical-session.target" ];
+      ConditionEnvironment = "WAYLAND_DISPLAY";
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${pkgs.eww}/bin/eww --no-daemonize daemon";
+      Restart = "on-failure";
+      RestartSec = "1s";
+    };
+    Install = {
+      WantedBy = [ "graphical-session.target" ];
+    };
+  };
+
+  # Tray-ready gate. Opens the bar window then blocks until eww has won the
+  # StatusNotifierWatcher race (see eww-start above). SNI clients depend on
+  # this unit, not eww-daemon, so they only start once the tray is usable.
+  systemd.user.services.eww = {
+    Unit = {
+      Description = "ElKowar's wacky widgets - bar window";
+      PartOf = [ "graphical-session.target" ];
+      After = [ "graphical-session.target" "eww-daemon.service" ];
+      BindsTo = [ "eww-daemon.service" ];
+      ConditionEnvironment = "WAYLAND_DISPLAY";
+    };
+    Service = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = "${eww-start}";
+      ExecStop = "${pkgs.eww}/bin/eww close bar";
+    };
+    Install = {
+      WantedBy = [ "graphical-session.target" ];
+    };
   };
 }

--- a/modules/home/linux/hyprland.nix
+++ b/modules/home/linux/hyprland.nix
@@ -3,5 +3,17 @@
 {
   xdg.configFile = {
     "hypr".source = config.lib.file.mkOutOfStoreSymlink "${userConfig.dotfilesPath}/config/hypr";
+
+    # Disable XDG autostart so .desktop files in etc/xdg/autostart/ don't silently
+    # race against our explicit systemd user services (notably the eww systray
+    # watcher, which loses the dbus name race when blueman.desktop autostart fires
+    # first). The bridge target (wayland-session-xdg-autostart@.target) isn't what
+    # pulls in the per-app units -- xdg-desktop-autostart.target does via Wants=,
+    # and the app-X@autostart.service instances also get pulled in directly. So
+    # mask the template itself, which covers every generated instance.
+    "systemd/user/app-@autostart.service.d/disable.conf".text = ''
+      [Unit]
+      ConditionPathExists=/nonexistent
+    '';
   };
 }

--- a/modules/home/linux/nm-applet.nix
+++ b/modules/home/linux/nm-applet.nix
@@ -6,7 +6,8 @@
       Description = "NetworkManager applet";
       Documentation = "https://gitlab.gnome.org/GNOME/network-manager-applet";
       PartOf = [ "graphical-session.target" ];
-      After = [ "graphical-session.target" ];
+      After = [ "graphical-session.target" "eww.service" ];
+      Requires = [ "eww.service" ];
       ConditionEnvironment = "WAYLAND_DISPLAY";
     };
     Service = {

--- a/modules/machines/deadmau5/system.nix
+++ b/modules/machines/deadmau5/system.nix
@@ -42,10 +42,13 @@
     ACTION=="add|change", KERNEL=="nvme[0-9]*", ATTR{queue/scheduler}="none"
   '';
 
-  # Ensure Sunshine starts after graphical session is ready
+  # Ensure Sunshine starts after graphical session and the eww systray watcher
+  # (modules/home/linux/eww.nix) is up; otherwise Sunshine can race for the SNI
+  # watcher name and break the tray.
   systemd.user.services.sunshine = {
-    after = [ "graphical-session.target" ];
+    after = [ "graphical-session.target" "eww.service" ];
     wants = [ "graphical-session.target" ];
+    requires = [ "eww.service" ];
     serviceConfig.Restart = "on-failure";
   };
 

--- a/modules/system/nixos/bluetooth.nix
+++ b/modules/system/nixos/bluetooth.nix
@@ -7,8 +7,17 @@
 
   # blueman ships its own user unit with ExecStart=; NixOS's drop-in adds another
   # ExecStart= which systemd rejects for non-oneshot services. Reset before re-setting.
-  systemd.user.services.blueman-applet.serviceConfig.ExecStart = lib.mkForce [
-    ""
-    "${pkgs.blueman}/bin/blueman-applet"
-  ];
+  #
+  # The upstream blueman-applet.service has no ordering relative to
+  # graphical-session.target, so add it explicitly (After + PartOf) to match
+  # nm-applet/sunshine/eww and avoid races during session start/stop.
+  systemd.user.services.blueman-applet = {
+    after = [ "graphical-session.target" "eww.service" ];
+    requires = [ "eww.service" ];
+    partOf = [ "graphical-session.target" ];
+    serviceConfig.ExecStart = lib.mkForce [
+      ""
+      "${pkgs.blueman}/bin/blueman-applet"
+    ];
+  };
 }


### PR DESCRIPTION
The eww 0.6.0 StatusNotifierWatcher silently queues for the
org.kde.StatusNotifierWatcher dbus name instead of requesting it
with DoNotQueue. When another SNI client (blueman-applet via XDG
autostart, nm-applet, sunshine) claims the name first, eww's host
registration ends up on the squatter's watcher. Once the squatter
exits, eww inherits the name but with empty internal state, so
tray icons never appear in the bar.

Move eww off Hyprland's exec-once and onto a pair of systemd user
units: eww-daemon runs the daemon in the foreground so its logs
land in the journal and systemd can manage its lifecycle, and a
second eww.service oneshot opens the bar and then blocks until
eww owns both StatusNotifierWatcher and a matching
StatusNotifierHost-* name on the same connection. SNI clients
order themselves After=eww.service with Requires=, so they only
start once the tray is provably usable.

Also mask the app-@autostart.service template so XDG autostart
.desktop files (blueman ships one) cannot silently race the
explicit user units behind our backs.
