### PR TITLE
Disable setuid on bwrap wrapper for Steam sandboxing

### DIFF
--- a/modules/system/nixos/steam.nix
+++ b/modules/system/nixos/steam.nix
@@ -1,6 +1,13 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 {
+  security.wrappers.bwrap = lib.mkForce {
+    source = "${pkgs.bubblewrap}/bin/bwrap";
+    owner = "root";
+    group = "root";
+    setuid = false;
+  };
+
   programs = {
     gamemode = {
       enable = true;


### PR DESCRIPTION
NixOS installs bwrap as a setuid root wrapper by default, but Steam's
container runtime (pressure-vessel) and other game sandboxes need to
invoke bwrap to set up nested user namespaces. A setuid bwrap drops
privileges in a way that prevents this nesting from working, causing
games that rely on the Steam Linux Runtime to fail to launch.

Modern kernels support unprivileged user namespaces, so the setuid bit
is no longer required for bwrap to function. Forcing it off lets Steam's
own sandbox set itself up correctly while keeping bwrap usable for
everything else on the system.
