### PR TITLE
stateVersion: centralize home + system to single definitions, bump to 26.05

### DIFF
--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -4,7 +4,7 @@
   home = {
     username = userConfig.username;
     homeDirectory = userConfig.homeDirectory;
-    stateVersion = "24.05";
+    stateVersion = "26.05";
   };
 
   home.file = {

--- a/modules/machines/archimedes/home.nix
+++ b/modules/machines/archimedes/home.nix
@@ -2,8 +2,6 @@
 { config, pkgs, lib, userConfig, ... }:
 
 {
-  home.stateVersion = "24.05";
-
   imports = [
     ../../home/meta/cli.nix
   ];

--- a/modules/machines/archimedes/system.nix
+++ b/modules/machines/archimedes/system.nix
@@ -140,6 +140,4 @@
       ];
     }
   ];
-
-  system.stateVersion = "24.05";
 }

--- a/modules/machines/deadmau5/home.nix
+++ b/modules/machines/deadmau5/home.nix
@@ -4,8 +4,6 @@
   nixpkgs.config.allowInsecurePredicate = pkg:
     builtins.elem (lib.getName pkg) [ "ventoy-gtk3" ];
 
-  home.stateVersion = "24.05";
-
   imports = [
     ../../home/meta/cli.nix
     ../../home/meta/gui-linux.nix

--- a/modules/machines/deadmau5/system.nix
+++ b/modules/machines/deadmau5/system.nix
@@ -222,11 +222,4 @@
     };
   };
 
-  # This value determines the NixOS release from which the default
-  # settings for stateful data, like file locations and database versions
-  # on your system were taken. It's perfectly fine and recommended to leave
-  # this value at the release version of the first install of this system.
-  # Before changing this value read the documentation for this option
-  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "24.05";
 }

--- a/modules/machines/docker/home.nix
+++ b/modules/machines/docker/home.nix
@@ -1,8 +1,6 @@
 { config, pkgs, lib, userConfig, ... }:
 
 {
-  home.stateVersion = "24.05";
-
   # Disable nix management to avoid conflicts with base image's nix installation
   # The base nixos/nix image already has nix configured properly
   nix.enable = false;

--- a/modules/machines/dosvec/home.nix
+++ b/modules/machines/dosvec/home.nix
@@ -1,8 +1,6 @@
 { config, pkgs, lib, userConfig, ... }:
 
 {
-  home.stateVersion = "24.05";
-
   imports = [
     ../../home/meta/cli.nix
   ];

--- a/modules/machines/dosvec/system.nix
+++ b/modules/machines/dosvec/system.nix
@@ -218,6 +218,4 @@
   #   dates = "04:00";
   #   allowReboot = false;
   # };
-
-  system.stateVersion = "24.05";
 }

--- a/modules/system/nixos/default.nix
+++ b/modules/system/nixos/default.nix
@@ -99,5 +99,10 @@
 
   programs.fish.enable = true;
 
-  system.stateVersion = "24.05";
+  # NixOS state version for all hosts (single source of truth). Determines
+  # defaults for stateful data (file locations, DB versions, daemon defaults).
+  # Bumped 24.05 -> 26.05 deliberately after auditing every gated change in
+  # the pinned nixpkgs; the only one that applied to this config was docker's
+  # live-restore default, which is pinned explicitly in docker.nix.
+  system.stateVersion = "26.05";
 }

--- a/modules/system/nixos/docker.nix
+++ b/modules/system/nixos/docker.nix
@@ -8,6 +8,12 @@
       enable = true;
       dates = "weekly";
     };
+
+    # Preserve the pre-24.11 NixOS default: keep running containers alive
+    # across docker daemon restarts. NixOS flipped this default to upstream's
+    # `false` at stateVersion 24.11; pin it so bumping stateVersion doesn't
+    # change daemon-restart behavior.
+    daemon.settings.live-restore = true;
   };
 
   # Allow Docker containers to communicate with host services


### PR DESCRIPTION
Collapse the duplicated home.stateVersion (4 machine copies) and
system.stateVersion (3 NixOS host copies) into the single base definitions
in modules/home/default.nix and modules/system/nixos/default.nix, which every
machine/host imports. Bump both 24.05 -> 26.05 (the newest the pinned
home-manager input and nixpkgs 26.05.20260523 accept).

Audited every state-version-gated change in the pinned nixpkgs/home-manager
against the actual config:
  - home: all gated changes are no-ops here (options set explicitly or HM
    modules not used; configs are symlinked).
  - system: no postgres/mysql/redis run as NixOS services, so the DB-version
    gates don't apply. The only gate that touches this config is docker's
    daemon.settings.live-restore default (true -> false at stateVersion 24.11),
    so pin it to true in docker.nix to preserve current behavior. deadmau5 is
    the only host that enables the docker daemon.

All four homeConfigurations and all three nixosConfigurations build.
